### PR TITLE
Add tvOS documentation and revise quickstart instructions

### DIFF
--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -16,6 +16,8 @@ with the
 
 ## Notes
 
+### Usage on tvOS
+
 * This testapp was designed for use on iOS and Android targets, and when
   running in the Unity editor. While the code will also execute on tvOS, there
   isn't an easy way for users to provide the click events required to use the
@@ -32,7 +34,7 @@ with the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -72,7 +74,7 @@ with the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.analytics.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -70,7 +70,7 @@ with the
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.analytics.testapp`
       as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -81,7 +81,7 @@ with the
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
         `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
-  - Build for iOS or tvOS
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
     - Select either `iOS` or `tvOS` in the `Platform` list.
     - Click `Switch Platform` to enable your selection as the target platform.
@@ -187,7 +187,7 @@ with the
 
 ## Using the Sample
 
-**Note:** that the UI Elements of the quickstart app respond to mouse clicks,
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
 and so will not be responsive on tvOS.
 
 The sample provides a simple interface with several buttons, demonstrating

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -88,7 +88,7 @@ with the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -8,9 +8,9 @@ with the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -30,14 +30,14 @@ UI elements on that platform.
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console.
       This file identifies your iOS+ app to the Firebase backend, and will
@@ -53,13 +53,13 @@ UI elements on that platform.
     - Select the **File > Open Project** menu item.
     - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      ***Open**.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
         Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Analytics` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Analytics` plugin.
+  - Import the Firebase Analytics plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAnalytics.unitypackage`.
@@ -74,15 +74,16 @@ UI elements on that platform.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.analytics.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your build
         target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
-        to **Bundle Identifier** and update the value to the `Apple bundle ID`
-        you provided when you registered your app with Firebase.
+        to **Bundle Identifier** and update the value to the
+        **Apple bundle ID** you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
     - Select either **iOS** or **tvOS** in the **Platform** list.
@@ -90,7 +91,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -98,14 +99,14 @@ UI elements on that platform.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Android app`.
+      - Check the box labeled **Register as Android app**.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
-        Android package name while you're testing.
+        **Android package name** while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -114,7 +115,8 @@ UI elements on that platform.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using
+          **Create a new key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -125,9 +127,9 @@ UI elements on that platform.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
-          will illuminate if the string is valid.  If it's not valid, check
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
+          will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
@@ -150,7 +152,7 @@ UI elements on that platform.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Analytics` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Analytics` plugin.
+  - Import the Firebase Analytics plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAnalytics.unitypackage`.
@@ -165,7 +167,7 @@ UI elements on that platform.
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.analytics.testapp`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.
@@ -180,7 +182,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -99,7 +99,7 @@ UI elements on that platform.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
-      and selecting `Unity`.
+      and selecting the **Unity** icon.
       - Check the box labeled `Register as Android app`.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
         Android package name while you're testing.
@@ -110,7 +110,8 @@ UI elements on that platform.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -218,7 +219,6 @@ the [Firebase Console](https://firebase.google.com/console/)).
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -19,9 +19,10 @@ with the
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Building the Sample
 

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -18,10 +18,10 @@ with the
 
 ### Usage on tvOS
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Building the Sample
 
@@ -44,20 +44,20 @@ with the
       need to be included in the sample later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describe how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      ***Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Analytics` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Analytics` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Analytics` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -66,8 +66,8 @@ with the
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Analytics` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Analytics` folder in the
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
@@ -76,20 +76,20 @@ with the
     - If you did not use `com.google.firebase.unity.analytics.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your build
         target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `Apple bundle ID` you
-        provided when you registered your app with Firebase.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
+        to **Bundle Identifier** and update the value to the `Apple bundle ID`
+        you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 
@@ -134,56 +134,51 @@ with the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Analytics` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Analytics` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Analytics` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseAnalytics.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseAnalytics.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseAnalytics.unitypackage` package.
+      downloaded previously, import `FirebaseAnalytics.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Analytics` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Analytics` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.analytics.testapp`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the package name you
+        provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -14,27 +14,36 @@ with the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
 
 ## Building the Sample
 
-### iOS
+### iOS and tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting `Unity`.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
-        iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
+      This file identifies your iOS+ app to the Firebase backend, and will
       need to be included in the sample later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
@@ -51,13 +60,7 @@ with the
   - Import the `Firebase Analytics` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseAnalytics.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseAnalytics.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseAnalytics.unitypackage` package.
+      downloaded previously, import `FirebaseAnalytics.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
@@ -69,18 +72,19 @@ with the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier
     - If you did not use `com.google.firebase.unity.analytics.testapp`
-      as the iOS bundle ID when creating your app in the Firebase
+      as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
+      - Click `Player Settings`.
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.
@@ -90,9 +94,11 @@ with the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting `Unity`.
+      - Check the box labeled `Register as Android app`.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -181,6 +187,9 @@ with the
 
 ## Using the Sample
 
+**Note:** that the UI Elements of the quickstart app respond to mouse clicks,
+and so will not be responsive on tvOS.
+
 The sample provides a simple interface with several buttons, demonstrating
 various ways of logging Firebase Analytics events:
 
@@ -195,8 +204,8 @@ various ways of logging Firebase Analytics events:
  - `Log Level Up` button logs a level-up event, via a Firebase Analytics
    event with multiple parameters, passed in as an array of parameters.
 
-Press some of the buttons to log some events to your Firebase project.
-After around 5 hours, data should be visible under the *Analytics* tab in
+Press some of the buttons to log some events to your Firebase project. After
+around 5 hours, data should be visible under the *Analytics* tab in
 the [Firebase Console](https://firebase.google.com/console/)).
 
 

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -14,16 +14,6 @@ with the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Building the Sample
 
 ### iOS or tvOS
@@ -185,11 +175,17 @@ that platform.
     - Click **Build and Run**.
   - See the **Using the Sample** section below.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Using the Sample
-
-**Note:** the UI elements of the quickstart app respond only to mouse clicks,
-and so will not be responsive on tvOS.
 
 The sample provides a simple interface with several buttons, demonstrating
 various ways of logging Firebase Analytics events:

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -225,8 +225,11 @@ the [Firebase Console](https://firebase.google.com/console/)).
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -23,13 +23,13 @@ with the
 
 ## Building the Sample
 
-### iOS and tvOS
+### iOS or tvOS
 
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
-      and selecting `Unity`.
+      and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.analytics.testapp` as the
         Apple bundle ID when creating the Unity app in the console.
@@ -79,7 +79,7 @@ with the
         target.
       - Click `Player Settings`.
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
   - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -17,10 +17,13 @@ with the
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Building the Sample
 

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -41,10 +41,10 @@ that platform.
           update the bundle identifier in Unity as described in the
           **Optional: Update the Project Bundle Identifier** below.
     - Enable Authentication in the project.
-      - Go to the [Firebase console](https://firebase.google.com/console/),
-      - Select the *Auth* tab in the sidebar.
-      - Select the *Sign-In Method* tab
-      - Enable *Email/Password* and *Anonymous* sign-in providers.
+      - Go to the [Firebase console](https://firebase.google.com/console/).
+      - Select the **Auth**tab in the sidebar.
+      - Select the **Sign-In Method** tab
+      - Enable **Email/Password** and **Anonymous** sign-in providers.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+ app
       to the Firebase backend, and will need to be included in the sample
@@ -142,7 +142,7 @@ that platform.
     - Enable Authentication in the project.
       - Go to the [Firebase console](https://firebase.google.com/console/),
       - Select the **Auth** tab in the sidebar.
-      - Select the **Sign-In Method** tab
+      - Select the **Sign-In Method** tab.
       - Enable **Email/Password** and **Anonymous** sign-in providers.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
@@ -216,7 +216,7 @@ user associated with the action performed by each of the following buttons:
     specified email address.
 
 The user database can be viewed in the
-[Firebase console.](https://firebase.google.com/console/) by:
+[Firebase console](https://firebase.google.com/console/) by:
   - Selecting the **Auth** sidebar.
   - Selecting the **Users** tab.
 
@@ -245,9 +245,11 @@ If any of these options fail please ensure that you have:
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
-
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 ## Support
 

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -15,21 +15,11 @@ with the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Building the Sample
 
 ### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
@@ -42,7 +32,7 @@ that platform.
           **Optional: Update the Project Bundle Identifier** below.
     - Enable Authentication in the project.
       - Go to the [Firebase console](https://firebase.google.com/console/).
-      - Select the **Auth**tab in the sidebar.
+      - Select the **Auth** tab in the sidebar.
       - Select the **Sign-In Method** tab
       - Enable **Email/Password** and **Anonymous** sign-in providers.
     - Download the `GoogleService-Info.plist` file associated with your
@@ -98,7 +88,7 @@ that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-    - Build the Xcode project by selecting **Project->Run** from the menu.
+    - Build the Xcode project by selecting **Project > Run** from the menu.
   - See the **Using the Sample** section below.
 
 
@@ -195,11 +185,17 @@ that platform.
     - Click **Build and Run**.
   - See the **Using the Sample** section below.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Using the Sample
-
-**Note:** the UI elements of the quickstart app respond only to mouse clicks,
-and so will not be responsive on tvOS.
 
 The app provides email and password text input fields which control the
 user associated with the action performed by each of the following buttons:

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -101,9 +101,11 @@ with the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Android app`.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
         `Android package name` while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -113,7 +115,8 @@ with the
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -48,20 +48,20 @@ with the
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Auth` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Auth` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Auth` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -70,7 +70,7 @@ with the
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Auth` folder in the `Project`
+    - Navigate to the `Assets/Firebase/Sample/Auth` folder in the **Project**
       window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
@@ -80,21 +80,21 @@ with the
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `Apple bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
+        to **Bundle Identifier** and update the value to the `Apple bundle ID`
+        you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
-    - Build the Xcode project by selecting `Project->Run` from the menu.
+    - Click **Build and Run**.
+    - Build the Xcode project by selecting **Project->Run** from the menu.
   - See the *Using the Sample* section below.
 
 
@@ -142,28 +142,23 @@ with the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Auth` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Auth` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Auth` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseAuth.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseAuth.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseAuth.unitypackage` package.
+      downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.
@@ -173,23 +168,23 @@ with the
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the Android package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the Android package name
+        you provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platfor** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -95,7 +95,7 @@ with the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -9,9 +9,9 @@ with the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -31,12 +31,12 @@ with the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Enable Authentication in the project.
       - Go to the [Firebase console](https://firebase.google.com/console/),
       - Select the *Auth* tab in the sidebar.
@@ -63,7 +63,7 @@ with the
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Auth` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Auth` plugin.
+  - Import the Firebase Auth plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAuth.unitypackage`.
@@ -78,15 +78,16 @@ with the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
         build target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
-        to **Bundle Identifier** and update the value to the `Apple bundle ID`
-        you provided when you registered your app with Firebase.
+        to **Bundle Identifier** and update the value to the
+        **Apple bundle ID** you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
     - Select either **iOS** or **tvOS** in the **Platform** list.
@@ -95,7 +96,7 @@ with the
       of the Unity status bar.
     - Click **Build and Run**.
     - Build the Xcode project by selecting **Project->Run** from the menu.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -103,14 +104,14 @@ with the
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Android app`.
+      - Check the box labeled **Register as Android app**.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
-        `Android package name` while you're testing.
+        **Android package name** while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -119,7 +120,8 @@ with the
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using
+          **Create a new key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -130,15 +132,15 @@ with the
           - From the main console view, click on your Android App at the top,
             then click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
           will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Enable Authentication in the project.
       - Go to the [Firebase console](https://firebase.google.com/console/),
-      - Select the *Auth* tab in the sidebar.
-      - Select the *Sign-In Method* tab
-      - Enable *Email/Password* and *Anonymous* sign-in providers.
+      - Select the **Auth** tab in the sidebar.
+      - Select the **Sign-In Method** tab
+      - Enable **Email/Password** and **Anonymous** sign-in providers.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
         This file identifies your Android app to the Firebase backend, and will
@@ -158,22 +160,22 @@ with the
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Auth` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Auth` plugin.
+  - Import the Firebase Auth plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Auth` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Auth` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.
@@ -188,7 +190,7 @@ with the
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample
@@ -212,15 +214,16 @@ user associated with the action performed by each of the following buttons:
 
 The user database can be viewed in the
 [Firebase console.](https://firebase.google.com/console/) by:
-  - Selecting the `Auth` sidebar.
-  - Selecting the `Users` tab.
+  - Selecting the **Auth** sidebar.
+  - Selecting the **Users** tab.
 
 If any of these options fail please ensure that you have:
-   - enabled *Email/Password* and *Anonymous* sign-in methods in your Firebase
-     project in the [Firebase console](https://firebase.google.com/console/) as
-     described in the section `Enable Authentication in the project` above,
+   - enabled **Email/Password** and **Anonymous** sign-in methods in your
+     Firebase project in the
+     [Firebase console](https://firebase.google.com/console/) as described in
+     the section **Enable Authentication in the project** above,
    - on Android you've signed your application with the same key that's
-     registered in the Firebase console.  See the `generated a SHA1 digest`
+     registered in the Firebase console.  See the **generate a SHA1 digest**
      section above.
 
 

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -76,7 +76,7 @@ with the
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
       as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -87,7 +87,7 @@ with the
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
         `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
-  - Build for iOS or tvOS
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
     - Select either `iOS` or `tvOS` in the `Platform` list.
     - Click `Switch Platform` to enable your selection as the target platform.
@@ -194,6 +194,9 @@ with the
 
 
 ## Using the Sample
+
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
+and so will not be responsive on tvOS.
 
 The app provides email and password text input fields which control the
 user associated with the action performed by each of the following buttons:

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -33,7 +33,7 @@ with the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
           `Optional: Update the Project Bundle Identifier` below.
@@ -78,7 +78,7 @@ with the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -24,13 +24,13 @@ with the
 
 ## Building the Sample
 
-### iOS and tvOS
+### iOS or tvOS
 
   - Register your iOS app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
-      and selecting `Unity`.
+      and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
         Apple bundle ID when creating the Unity app in the console.
@@ -43,9 +43,9 @@ with the
       - Select the *Sign-In Method* tab
       - Enable *Email/Password* and *Anonymous* sign-in providers.
     - Download the `GoogleService-Info.plist` file associated with your
-      Firebase project from the console.
-      This file identifies your iOS+ app to the Firebase backend, and will
-      need to be included in the sample later.
+      Firebase project from the console. This file identifies your iOS+ app
+      to the Firebase backend, and will need to be included in the sample
+      later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
       which describes how to configure a Firebase application for iOS
@@ -66,13 +66,7 @@ with the
   - Import the `Firebase Auth` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseAuth.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseAuth.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseAuth.unitypackage` package.
+      downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
@@ -91,7 +85,7 @@ with the
         target.
       - Click `Player Settings`.
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
   - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -15,17 +15,25 @@ with the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
 
 ## Building the Sample
 
-### iOS
+### iOS and tvOS
 
   - Register your iOS app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting `Unity`.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityAuthTestApp.dev` as the
-        iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
           `Optional: Update the Project Bundle Identifier` below.
@@ -36,11 +44,12 @@ with the
       - Enable *Email/Password* and *Anonymous* sign-in providers.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
+      This file identifies your iOS+ app to the Firebase backend, and will
       need to be included in the sample later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
@@ -75,25 +84,22 @@ with the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier
     - If you did not use `com.google.FirebaseUnityAuthTestApp.dev`
-      as the iOS bundle ID when creating your app in the Firebase
+      as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`, when Xcode opens stop the build.
-    - Configure the Xcode project for push messaging.
-      - Select the `Unity-iPhone` project from the `Navigator area`.
-      - Select the `Capabilities` tab from the `Editor area`.
-      - Switch `Push Notifications` to `On`.
+    - Click `Build and Run`.
     - Build the Xcode project by selecting `Project->Run` from the menu.
   - See the *Using the Sample* section below.
 

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -190,6 +190,9 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ## Testing and Validation
 
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
+and so will not be responsive on tvOS.
+
   - Once the Unity test app is running (detach debugger if attached), click the
     `Perform All Actions` button.
   - Trigger upload by completely closing and relaunching the test app.

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -39,12 +39,7 @@ inside the Unity Editor.
   - Import the `Firebase Crashlytics` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseCrashlytics.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - If your project is configured to use .NET 3.x, import the
-         `dotnet3/FirebaseCrashlytics.unitypackage` package.
-       - If your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseCrashlytics.unitypackage` package.
+      downloaded previously, import `FirebaseCrashlytics.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
 
@@ -52,8 +47,7 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ## Building the Sample for Devices
 
-### iOS
-
+### iOS or tvOS
 
   - [Create a new Firebase project and Unity iOS app](https://firebase.google.com/docs/unity/setup).
     - You should use `com.google.firebase.unity.crashlytics.testapp` as the
@@ -67,6 +61,21 @@ Once you have done this, you can run the Unity Editor and test the application.
       [general instructions](https://firebase.google.com/docs/ios/setup)
       which describes how to configure a Firebase application for iOS
       and tvOS.
+  - Select `File > Open Project` menu item.
+    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Navigate to this sample project directory `testapp` in the file dialog and
+      click `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the `Project` window.
+    - Double click on the `MainScene` file to open it.
+  - Import the `Firebase Crashlytics` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseCrashlytics.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Crashlytics` folder in the 
       `Project` window.
@@ -74,12 +83,12 @@ Once you have done this, you can run the Unity Editor and test the application.
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Set up Crashlytics
+  - Set up Crashlytics.
     - In the Firebase console -> Select your project -> Select Crashlytics ->
       Setup Crashlytics -> Select that the app is new.
       (You do not need to download the SDK again as you have already downloaded
       the Unity plugin)
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
       as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -88,9 +97,9 @@ Once you have done this, you can run the Unity Editor and test the application.
         target.
       - Click `Player Settings`.
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
-  - Build for iOS or tvOS
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
     - Select either `iOS` or `tvOS` in the `Platform` list.
     - Click `Switch Platform` to enable your selection as the target platform.
@@ -133,6 +142,21 @@ Once you have done this, you can run the Unity Editor and test the application.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
         which describes how to configure a Firebase application for Android.
+  - Select `File > Open Project` menu item.
+    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Navigate to this sample project directory `testapp` in the file dialog and
+      click `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the `Project` window.
+    - Double click on the `MainScene` file to open it.
+  - Import the `Firebase Crashlytics` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseCrashlytics.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Crashlytics` folder in the
       `Project` window.

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -121,7 +121,8 @@ Once you have done this, you can run the Unity Editor and test the application.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -172,7 +173,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       Setup Crashlytics -> Select that the app is new.
       (You do not need to download the SDK again as you have already downloaded 
       the Unity plugin)
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -182,7 +183,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       - In the `Settings for Android` panel scroll down to `Bundle Identifier`
         and update the value to the Android package name you provided when you
         registered your app with Firebase.
-  - Build for Android
+  - Build for Android.
     - Select the `File > Build Settings` menu option.
     - Select `Android` in the `Platform` list.
     - Click `Switch Platform` to select `Android` as the target platform.
@@ -217,7 +218,6 @@ and so will not be responsive on tvOS.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -51,7 +51,7 @@ Once you have done this, you can run the Unity Editor and test the application.
 
   - [Create a new Firebase project and Unity iOS app](https://firebase.google.com/docs/unity/setup).
     - You should use `com.google.firebase.unity.crashlytics.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
           `Optional: Update the Project Bundle Identifier` below.
@@ -90,7 +90,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       the Unity plugin)
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -14,6 +14,13 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
+
 ## Running the Sample inside the Editor
 
   - Download the
@@ -47,17 +54,19 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ### iOS
 
+
   - [Create a new Firebase project and Unity iOS app](https://firebase.google.com/docs/unity/setup).
     - You should use `com.google.firebase.unity.crashlytics.testapp` as the
-      iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
           `Optional: Update the Project Bundle Identifier` below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console.
       - For further details please refer to the
-        [general instructions](https://firebase.google.com/docs/ios/setup)
-        which describes how to configure a Firebase application for iOS.
+      [general instructions](https://firebase.google.com/docs/ios/setup)
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Crashlytics` folder in the 
       `Project` window.
@@ -72,18 +81,19 @@ Once you have done this, you can run the Unity Editor and test the application.
       the Unity plugin)
   - Optional: Update the Project Bundle Identifier
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
-      as the iOS bundle ID when creating your app in the Firebase
+      as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -114,7 +114,7 @@ Once you have done this, you can run the Unity Editor and test the application.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -19,9 +19,10 @@ inside the Unity Editor.
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Running the Sample inside the Editor
 
@@ -110,7 +111,7 @@ Once you have done this, you can run the Unity Editor and test the application.
         build target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down to
-        **Bundle Identifier** and update the value to the **Apple bundle ID**` you
+        **Bundle Identifier** and update the value to the **Apple bundle ID** you
         provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
@@ -141,7 +142,8 @@ Once you have done this, you can run the Unity Editor and test the application.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using **Create a new
+          key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -238,8 +240,11 @@ and so will not be responsive on tvOS.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -16,10 +16,12 @@ inside the Unity Editor.
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Running the Sample inside the Editor
 
@@ -59,7 +61,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       Firebase project from the console.
       - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Select `File > Open Project` menu item.
     - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
@@ -141,7 +143,8 @@ Once you have done this, you can run the Unity Editor and test the application.
         Firebase project from the console.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Select `File > Open Project` menu item.
     - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
     - Navigate to this sample project directory `testapp` in the file dialog and

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -14,16 +14,6 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Running the Sample inside the Editor
 
   - Download the
@@ -53,7 +43,7 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
@@ -210,6 +200,15 @@ Once you have done this, you can run the Unity Editor and test the application.
       of the Unity status bar.
     - Click **Build and Run**.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Testing and Validation
 

--- a/crashlytics/testapp/readme.md
+++ b/crashlytics/testapp/readme.md
@@ -8,9 +8,9 @@ inside the Unity Editor.
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -29,16 +29,17 @@ UI elements on that platform.
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open this sample project in the Unity editor.
-    - Select `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
-    - Navigate to this sample project directory `testapp` in the file dialog and
-      click `Open`.
+    - Select **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
+    - Navigate to this sample project directory `testapp` in the file dialog
+      and click **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the **Project**
+      window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Crashlytics` plugin.
+  - Import the Firebase Crashlytics plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseCrashlytics.unitypackage`.
@@ -51,28 +52,38 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ### iOS or tvOS
 
-  - [Create a new Firebase project and Unity iOS app](https://firebase.google.com/docs/unity/setup).
-    - You should use `com.google.firebase.unity.crashlytics.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+  - Register your iOS app with Firebase.
+    - Create a project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled **Register as Apple app**.
+      - You should use `com.google.firebase.unity.crashlytics.testapp` as the
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console.
-      - For further details please refer to the
+    - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
       page which describes how to configure a Firebase application for iOS
       and tvOS.
-  - Select `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
-    - Navigate to this sample project directory `testapp` in the file dialog and
-      click `Open`.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity)
+    and unzip it somewhere convenient.
+  - Open the sample project in the Unity editor.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the **Project**
+      window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Crashlytics` plugin.
+  - Import the Firebase Crashlytics plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseCrashlytics.unitypackage`.
@@ -80,11 +91,11 @@ Once you have done this, you can run the Unity Editor and test the application.
       button.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Crashlytics` folder in the 
-      `Project` window.
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
-        `Assets` folder.
+        **Assets** folder.
   - Set up Crashlytics.
     - In the Firebase console -> Select your project -> Select Crashlytics ->
       Setup Crashlytics -> Select that the app is new.
@@ -92,31 +103,36 @@ Once you have done this, you can run the Unity Editor and test the application.
       the Unity plugin)
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `Apple bundle ID` you
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down to
+        **Bundle Identifier** and update the value to the **Apple bundle ID**` you
         provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
 
 ### Android
 
-  - [Create a new Firebase project and Unity Android app](https://firebase.google.com/docs/unity/setup).
-    - You should use `com.google.firebase.unity.crashlytics.testapp` as the
-        `Android package name` while you're testing.
+  - Register your Android app with Firebase.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the **Add app** button,
+      and selecting the **Unity** icon.
+      - Check the box labeled **Register as Android app**.
+      - You should use `com.google.firebase.unity.crashlytics.testapp` as the
+        **Android package name** while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -136,7 +152,7 @@ Once you have done this, you can run the Unity Editor and test the application.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
           - Scroll down to your apps at the bottom of the page and click on
-            `Add Fingerprint`.
+            **Add Fingerprint**.
         - Paste the SHA1 digest of your key into the form.  The SHA1 box
           will illuminate if the string is valid.  If it's not valid, check
           that you have copied the entire SHA1 digest string.
@@ -146,16 +162,17 @@ Once you have done this, you can run the Unity Editor and test the application.
         [general instructions](https://firebase.google.com/docs/android/setup)
         page which describes how to configure a Firebase application for
         Android.
-  - Select `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+  - Select **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to this sample project directory `testapp` in the file dialog and
-      click `Open`.
+      click **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Crashlytics` in the **Project**
+      window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Crashlytics` plugin.
+  - Import the Firebase Crashlytics plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseCrashlytics.unitypackage`.
@@ -163,33 +180,33 @@ Once you have done this, you can run the Unity Editor and test the application.
       button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Crashlytics` folder in the
-      `Project` window.
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Set up Crashlytics
+  - Set up Crashlytics.
     - In the Firebase console -> Select your project -> Select Crashlytics ->
       Setup Crashlytics -> Select that the app is new.
       (You do not need to download the SDK again as you have already downloaded 
       the Unity plugin)
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.crashlytics.testapp`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the Android package name you provided when you
-        registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to **Bundle
+        Identifier** and update the value to the **Android package name** you
+        provided when you registered your app with Firebase.
   - Build for Android.
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
 
 
 ## Testing and Validation

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -79,7 +79,7 @@ documentation.
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.database.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -119,7 +119,7 @@ documentation.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.database.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -16,10 +16,12 @@ inside the Unity Editor.
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Running the Sample inside the Editor
 
@@ -27,26 +29,19 @@ inside the Unity Editor.
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.Click `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Database` in the `Project`
-      window.
+    - Navigate to `Assets/Firebase/Sample/Database` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Database` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseDatabase.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseDatabase.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseDatabase.unitypackage` package.
+      downloaded previously, import `FirebaseDatabase.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Turn off secure access.  [Configure your rules for public access.](https://firebase.google.com/docs/database/security/quickstart#sample-rules)
@@ -61,10 +56,12 @@ leaderboard update.
     Firebase Database transaction to record the score if it falls within the
     current top 5 all time scores.
 
-Once you are ready to secure your database, you can [configure your rules](https://firebase.google.com/docs/database/security/quickstart#sample-rules) with
-private or user access and still access the database within the editor without
-logging in.  To do this, you will need to create a service account and register
-it with Firebase by following the steps in the [unity getting started](https://firebase.google.com/docs/database/unity/start/)
+Once you are ready to secure your database, you can
+[configure your rules](https://firebase.google.com/docs/database/security/quickstart#sample-rules)
+with private or user access and still access the database within the editor
+without logging in.  To do this, you will need to create a service account and
+register it with Firebase by following the steps in the
+[Unity getting started](https://firebase.google.com/docs/database/unity/start/)
 documentation.
 
 
@@ -89,20 +86,20 @@ documentation.
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Database` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Database` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Database` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -111,7 +108,7 @@ documentation.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Database` folder in the `Project`
+    - Navigate to the `Assets/Firebase/Sample/Auth` folder in the **Project**
       window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
@@ -121,20 +118,21 @@ documentation.
     - If you did not use `com.google.firebase.unity.database.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `Apple bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
+        to **Bundle Identifier** and update the value to the `Apple bundle ID`
+        you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
+    - Build the Xcode project by selecting **Project->Run** from the menu.
 
 ### Android
 
@@ -175,19 +173,20 @@ documentation.
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Database` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Database` in the **Project** window.
     - Double click on the `MainScene` file to open it.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Import the `Firebase Database` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
@@ -196,28 +195,28 @@ documentation.
       button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Database` folder in the
-      `Project` window.
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.database.testapp`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the Android package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the Android package name
+        you provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
 
 
 ## Troubleshooting

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -19,9 +19,10 @@ inside the Unity Editor.
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Running the Sample inside the Editor
 

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -130,7 +130,7 @@ documentation.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -137,9 +137,10 @@ documentation.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.database.testapp` as the
         `Android package name` while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -149,7 +150,8 @@ documentation.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -231,7 +233,6 @@ documentation.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -70,25 +70,54 @@ documentation.
 
 ## Building the Sample for Devices
 
-### iOS
+### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.database.testapp` as the
-        iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
+    - Download the `GoogleService-Info.plist` file associated with your
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
+    - For further details please refer to the
+      [general instructions](https://firebase.google.com/docs/ios/setup)
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity)
+    and unzip it somewhere convenient.
+  - Open the sample project in the Unity editor.
+    - Select the `File > Open Project` menu item.
+    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Database` in the `Project` window.
+    - Double click on the `MainScene` file to open it.
+  - Import the `Firebase Database` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseDatabase.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Database` folder in the
-      `Project` window.
+    - Navigate to the `Assets/Firebase/Sample/Database` folder in the `Project`
+      window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
-        `Assets` folder.  - Optional: Update the Project Bundle Identifier
-    - Optional: Update the Project Bundle Identifier
+        `Assets` folder.
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.database.testapp`
       as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -97,9 +126,9 @@ documentation.
         target.
       - Click `Player Settings`.
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
-  - Build for iOS or tvOS
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
     - Select either `iOS` or `tvOS` in the `Platform` list.
     - Click `Switch Platform` to enable your selection as the target platform.
@@ -147,6 +176,24 @@ documentation.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
         which describes how to configure a Firebase application for Android.
+  - Open the sample project in the Unity editor.
+    - Select the `File > Open Project` menu item.
+    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Database` in the `Project` window.
+    - Double click on the `MainScene` file to open it.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Import the `Firebase Database` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseDatabase.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Database` folder in the
       `Project` window.

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -14,6 +14,13 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
+
 ## Running the Sample inside the Editor
 
   - Download the
@@ -82,19 +89,20 @@ documentation.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.  - Optional: Update the Project Bundle Identifier
     - Optional: Update the Project Bundle Identifier
-    - If you did not use `com.google.firebase.unity.database.testapp` as the
-      iOS bundle ID when creating your app in the Firebase Console then you will
-      need to update the sample's Bundle.
+    - If you did not use `com.google.firebase.unity.database.testapp`
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -157,7 +157,8 @@ documentation.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using **Create a new
+          key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -223,7 +224,6 @@ documentation.
       of the Unity status bar.
     - Click **Build and Run**.
 
-
 ## Troubleshooting
 
   - When upgrading to a new Firebase release: import the new firebase
@@ -239,8 +239,11 @@ documentation.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -14,16 +14,6 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Running the Sample inside the Editor
 
   - Download the
@@ -135,7 +125,7 @@ documentation.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-    - Build the Xcode project by selecting **Project->Run** from the menu.
+    - Build the Xcode project by selecting **Project > Run** from the menu.
 
 ### Android
 
@@ -224,6 +214,16 @@ documentation.
       of the Unity status bar.
     - Click **Build and Run**.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
+
 ## Troubleshooting
 
   - When upgrading to a new Firebase release: import the new firebase
@@ -244,7 +244,6 @@ documentation.
   - When running the app, if all that you see is a blue horizon, then please
     ensure that you followed the steps to **Open the scene `MainScene`**
     above.
-
 
 ## Support
 

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -8,9 +8,9 @@ inside the Unity Editor.
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -38,13 +38,14 @@ UI elements on that platform.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Database` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Database` plugin.
+  - Import the Firebase Database plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseDatabase.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
-  - Turn off secure access.  [Configure your rules for public access.](https://firebase.google.com/docs/database/security/quickstart#sample-rules)
+  - Turn off secure access. 
+    [Configure your rules for public access.](https://firebase.google.com/docs/database/security/quickstart#sample-rules)
 
 Once you have done this, you can run the Unity Editor and test the application.
 You will be able to enter an email, a score, and press `Add Score` to see the
@@ -72,14 +73,14 @@ documentation.
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.database.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -101,7 +102,7 @@ documentation.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Database` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Database` plugin.
+  - Import the Firebase Database plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseDatabase.unitypackage`.
@@ -116,15 +117,16 @@ documentation.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.database.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
         build target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
-        to **Bundle Identifier** and update the value to the `Apple bundle ID`
-        you provided when you registered your app with Firebase.
+        to **Bundle Identifier** and update the value to the
+        **Apple bundle ID** you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
     - Select either **iOS** or **tvOS** in the **Platform** list.
@@ -139,13 +141,13 @@ documentation.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.database.testapp` as the
-        `Android package name` while you're testing.
+        **Android package name** while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -165,7 +167,7 @@ documentation.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
           - Scroll down to your apps at the bottom of the page and click on
-            `Add Fingerprint`.
+            **Add Fingerprint**.
         - Paste the SHA1 digest of your key into the form.  The SHA1 box
           will illuminate if the string is valid.  If it's not valid, check
           that you have copied the entire SHA1 digest string.
@@ -189,7 +191,7 @@ documentation.
     - Double click on the `MainScene` file to open it.
       - You might be prompted to upgrade the project to your version of Unity.
         Click **Confirm** to upgrade the project and continue.
-  - Import the `Firebase Database` plugin.
+  - Import the Firebase Database plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseDatabase.unitypackage`.
@@ -204,7 +206,7 @@ documentation.
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.database.testapp`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -85,7 +85,8 @@ using the
       the `UIHandler` object in the `MainScene`.
     - Optional: If you want to use a custom Dynamic Links domain, follow
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
-      to set up the domain in Firebase console and in your project's `Info.plist`.
+      to set up the domain in Firebase console and in your project's
+      `Info.plist`.
   - Build for iOS.
     - Select the **File > Build Settings** menu option.
     - Select **iOS** in the **Platform** list.
@@ -94,16 +95,17 @@ using the
       of the Unity status bar.
     - Click **Build and Run**.
   - Configure the Xcode project capabilities to send invites and receive links.
-    - Enable the Keychain Sharing capability on iOS 10 or above (required by
-      Google Sign-In to send invites).
-      You can enable this capability on your project in Xcode 8 by going to
-      your project's settings, Capabilities, and turning on Keychain Sharing.
+    - Enable the Keychain Sharing capability (required by Google Sign-In to
+      send invites).
+      - You can enable this capability on your project in Xcode by going to
+        your project's settings, **Capabilities**, and turning on
+        **Keychain Sharing**.
     - Copy the domain URI prefix for your project under the **Dynamic Links** tab of
       the [Firebase console](https://firebase.google.com/console/) Then, in your
       project's Capabilities tab:
       - Enable the Associated Domains capability.
-      - Add applinks:YOUR_DYNAMIC_LINKS_DOMAIN
-        For example: `applinks:xyz.app.goo.gl`.
+      - Add `applinks:YOUR_DYNAMIC_LINKS_DOMAIN`. For example:
+        `applinks:xyz.app.goo.gl`.
   - See the **Using the Sample** section below.
 
 

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -30,7 +30,7 @@ using the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -71,7 +71,7 @@ using the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` in the `Platform` list

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -208,6 +208,9 @@ using the
 
 ## Using the Sample
 
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
+and so will not be responsive on tvOS.
+
   - Receiving a link
     - When you first run the app, it will check for an incoming dynamic link
       and report whether it was able to fetch a link.

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -81,11 +81,11 @@ using the
         provided when you registered your app with Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
-    e.g xyz.app.goo.gl and assign it to the string DomainUriPrefix on the
-    UIHandler object in the MainScene.
+    e.g. `xyz.app.goo.gl` and assign it to the string **DomainUriPrefix** on
+      the `UIHandler` object in the `MainScene`.
     - Optional: If you want to use a custom Dynamic Links domain, follow
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
-      to set up the domain in Firebase console and in your project's Info.plist.
+      to set up the domain in Firebase console and in your project's `Info.plist`.
   - Build for iOS.
     - Select the **File > Build Settings** menu option.
     - Select **iOS** in the **Platform** list.
@@ -98,12 +98,12 @@ using the
       Google Sign-In to send invites).
       You can enable this capability on your project in Xcode 8 by going to
       your project's settings, Capabilities, and turning on Keychain Sharing.
-    - Copy the domain URI prefix for your project under the Dynamic Links tab of
+    - Copy the domain URI prefix for your project under the **Dynamic Links** tab of
       the [Firebase console](https://firebase.google.com/console/) Then, in your
       project's Capabilities tab:
       - Enable the Associated Domains capability.
       - Add applinks:YOUR_DYNAMIC_LINKS_DOMAIN
-        For example `applinks:xyz.app.goo.gl`.
+        For example: `applinks:xyz.app.goo.gl`.
   - See the **Using the Sample** section below.
 
 
@@ -188,10 +188,11 @@ using the
         **Bundle Identifier** and update the value to the
         **Android package name** you provided when you registered your app with
         Firebase.
-  - Copy the dynamic links domain URI prefix for your project under the Dynamic
-    Links tab of the [Firebase console](https://firebase.google.com/console/)
-    e.g xyz.app.goo.gl and assign it to the string DomainUriPrefix on the
-    UIHandler object in the MainScene.
+  - Copy the dynamic links domain URI prefix for your project under the
+    **Dynamic Links** tab of the
+    [Firebase console](https://firebase.google.com/console/)
+    e.g. `xyz.app.goo.gl` and assign it to the string **DomainUriPrefix** on the
+    `UIHandler` object in the `MainScene`.
     - Optional: If you want to use a custom Dynamic Links domain, follow
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
       to set up the domain in Firebase console.
@@ -245,8 +246,11 @@ and so will not be responsive on tvOS.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -15,6 +15,9 @@ using the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* Dynamic Links is not supported on tvOS targets.
 
 ## Building the Sample
 
@@ -22,17 +25,19 @@ using the
 
   - Register your iOS app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as the
-        bundle identifier when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
     - Download the `GoogleService-Info.plist` file associated with your
-      Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
-      need to be included in the sample later.
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
       which describes how to configure a Firebase application for iOS.
@@ -48,17 +53,13 @@ using the
         Click `Confirm` to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
-    - Double click on `MainScene` file to open.
+    - Double click on `MainScene` file to open it.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
   - Import the `Firebase Dynamic Links` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseDynamicLinks.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseDynamicLinks.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseDynamicLinks.unitypackage` package.
+      downloaded previously, import `FirebaseDynamicLinks.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
@@ -68,15 +69,15 @@ using the
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
-    - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as
-      the iOS bundle ID when creating your app in the Firebase Console then you
-      will need to update the sample's Bundle.
+  - Optional: Update the Project Bundle Identifier.
+    - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` in the `Platform` list
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
+      - In the `Settings for iOS` panel, scroll down to `Bundle Identifier` and
+        update the value to the `Apple bundle ID` you provided when you
         registered your app with Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
@@ -85,14 +86,14 @@ using the
     - Optional: If you want to use a custom Dynamic Links domain, follow
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
       to set up the domain in Firebase console and in your project's Info.plist.
-  - Build for iOS
+  - Build for iOS.
     - Select the `File > Build Settings` menu option.
     - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.
-  - Configure the iOS project capabilities to send invites and receive links.
+  - Configure the Xcode project capabilities to send invites and receive links.
     - Enable the Keychain Sharing capability on iOS 10 or above (required by
       Google Sign-In to send invites).
       You can enable this capability on your project in Xcode 8 by going to
@@ -158,7 +159,7 @@ using the
       `Open`.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
-    - Double click on `MainScene` file to open.
+    - Double click on `MainScene` file to open it.
   - Import the `Firebase Dynamic Links` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -9,8 +9,8 @@ using the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
   (when developing for iOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
@@ -26,14 +26,14 @@ using the
   - Register your iOS app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -56,28 +56,28 @@ using the
     - Double click on `MainScene` file to open it.
       - You might be prompted to upgrade the project to your version of Unity.
         Click **Confirm** to upgrade the project and continue.
-  - Import the `Firebase Dynamic Links` plugin.
+  - Import the Firebase Dynamic Links plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseDynamicLinks.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** in the **Platform** list
       - Click **Player Settings**.
-      - In the **Settings for iOS** panel, scroll down t
-        **Bundle Identifier** and update the value to the `Apple bundle ID` you
+      - In the **Settings for iOS** panel, scroll down to
+        **Bundle Identifier** and update the value to the **Apple bundle ID** you
         provided when you registered your app with Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
@@ -103,8 +103,8 @@ using the
       project's Capabilities tab:
       - Enable the Associated Domains capability.
       - Add applinks:YOUR_DYNAMIC_LINKS_DOMAIN
-        For example "applinks:xyz.app.goo.gl".
-  - See the *Using the Sample* section below.
+        For example `applinks:xyz.app.goo.gl`.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -112,13 +112,13 @@ using the
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as the
-        `Android package name` while you're testing.
+        **Android package name** while you're testing.
         - If you do not use the prescribed package name, you will need to update
-          the bundle identifier as described in `Optional: Update the Project
-          Bundle Identifier` below.
+          the bundle identifier as described in **Optional: Update the Project
+          Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -127,7 +127,8 @@ using the
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using 
+          **Create a new key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -138,8 +139,8 @@ using the
         - From the main console view, click on your Android App at the top, then
           click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
           will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
@@ -163,7 +164,7 @@ using the
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
-  - Import the `Firebase Dynamic Links` plugin.
+  - Import the Firebase Dynamic Links plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseDynamicLinks.unitypackage`.
@@ -178,14 +179,14 @@ using the
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.
       - Click **Player Settings**.
       - In the **Settings for Android** panel scroll down to
         **Bundle Identifier** and update the value to the
-        `Android package name` you provided when you registered your app with
+        **Android package name** you provided when you registered your app with
         Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
@@ -201,7 +202,7 @@ using the
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -17,7 +17,7 @@ using the
 
 ## Notes
 
-* Dynamic Links is not supported on tvOS targets.
+* Dynamic Links is not supported on tvOS.
 
 ## Building the Sample
 
@@ -40,22 +40,22 @@ using the
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
+      page which describes how to configure a Firebase application for iOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Import the `Firebase Dynamic Links` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
@@ -73,12 +73,12 @@ using the
     - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list
-      - Click `Player Settings`.
-      - In the `Settings for iOS` panel, scroll down to `Bundle Identifier` and
-        update the value to the `Apple bundle ID` you provided when you
-        registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** in the **Platform** list
+      - Click **Player Settings**.
+      - In the **Settings for iOS** panel, scroll down t
+        **Bundle Identifier** and update the value to the `Apple bundle ID` you
+        provided when you registered your app with Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
     e.g xyz.app.goo.gl and assign it to the string DomainUriPrefix on the
@@ -87,12 +87,12 @@ using the
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
       to set up the domain in Firebase console and in your project's Info.plist.
   - Build for iOS.
-    - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select **iOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - Configure the Xcode project capabilities to send invites and receive links.
     - Enable the Keychain Sharing capability on iOS 10 or above (required by
       Google Sign-In to send invites).
@@ -146,49 +146,45 @@ using the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
   - Import the `Firebase Dynamic Links` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseDynamicLinks.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseDynamicLinks.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseDynamicLinks.unitypackage` package.
+      downloaded previously, import `FirebaseDynamicLinks.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityDynamicLinksTestApp.dev`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the Android package name you provided when you
-        registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the
+        `Android package name` you provided when you registered your app with
+        Firebase.
   - Copy the dynamic links domain URI prefix for your project under the Dynamic
     Links tab of the [Firebase console](https://firebase.google.com/console/)
     e.g xyz.app.goo.gl and assign it to the string DomainUriPrefix on the
@@ -196,13 +192,13 @@ using the
     - Optional: If you want to use a custom Dynamic Links domain, follow
       [these instructions](https://firebase.google.com/docs/dynamic-links/custom-domains)
       to set up the domain in Firebase console.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -112,7 +112,7 @@ using the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/dynamic_links/testapp/readme.md
+++ b/dynamic_links/testapp/readme.md
@@ -110,9 +110,10 @@ using the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.FirebaseUnityDynamicLinksTestApp.dev` as the
         `Android package name` while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -122,7 +123,8 @@ using the
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -239,7 +241,6 @@ and so will not be responsive on tvOS.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -14,16 +14,6 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Deploying functions.
 - Install the [Firebase CLI](https://firebase.google.com/docs/cli/).
 - Deploy the provided functions.
@@ -245,6 +235,16 @@ Once you have done this, you can run the Unity Editor and test the application.
       of the Unity status bar.
     - Click **Build and Run**.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
+
 
 ## Troubleshooting
 
@@ -265,7 +265,7 @@ Once you have done this, you can run the Unity Editor and test the application.
     troubleshooting topics.
   - When running the app, if all that you see is a blue horizon, then please
     ensure that you followed the steps to **Open the scene `MainScene`**
-    above.`    
+    above.
 
 
 ## Support

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -145,7 +145,7 @@ Once you have done this, you can run the Unity Editor and test the application.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -84,7 +84,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.functions.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -130,7 +130,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       button.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -8,9 +8,9 @@ inside the Unity Editor.
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -51,22 +51,22 @@ UI elements on that platform.
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
        - You might be prompted to upgrade the project to your version of Unity.
-         Click `Confirm` to upgrade the project and continue.
+         Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
-  - Import the `Firebase Auth` plugin.
+  - Import the Firebase Auth plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
-  - Import the `Firebase Functions` plugin.
+  - Import the Firebase Functions plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseFunctions.unitypackage`
@@ -84,12 +84,12 @@ Once you have done this, you can run the Unity Editor and test the application.
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.functions.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -107,24 +107,24 @@ Once you have done this, you can run the Unity Editor and test the application.
     - Navigate to the sample directory `testapp` in the file dialog and click
       **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click *Confirm** to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
-        `Assets` folder.
-  - Import the `Firebase Auth` plugin.
+        **Assets** folder.
+  - Import the Firebase Auth plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
-  - Import the `Firebase Functions` plugin.
+  - Import the Firebase Functions plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseFunctions.unitypackage`
@@ -132,15 +132,16 @@ Once you have done this, you can run the Unity Editor and test the application.
       button.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
         build target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
-        to **Bundle Identifier** and update the value to the `Apple bundle ID`
-        you provided when you registered your app with Firebase.
+        to **Bundle Identifier** and update the value to the
+        **Apple bundle ID** you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
     - Select the  **File > Build Settings** menu option.
     - Select either **iOS** or **tvOS** in the **Platform** list.
@@ -155,17 +156,17 @@ Once you have done this, you can run the Unity Editor and test the application.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.functions.testapp` as the
-        `Android package name` when you created your app in the Firebase
+        **Android package name** when you created your app in the Firebase
         Console, you will need to update the sample's Bundle Identifier.
-        - Select the `File > Build Settings` menu option.
-        - Select `Android` in the `Platform` list.
-        - Click `Player Settings`
-        - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-          and update the value to the Android package name you provided when you
-          registered your app with Firebase.
+        - Select the **File > Build Settings** menu option.
+        - Select **Android** in the **Platform** list.
+        - Click **Player Settings**.
+        - In the **Settings for Android** panel scroll down to **Bundle
+          Identifier** and update the value to the Android package name you
+          provided when you registered your app with Firebase.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -184,8 +185,8 @@ Once you have done this, you can run the Unity Editor and test the application.
         - From the main console view, click on your Android App at the top, then
           click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
           will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
@@ -213,13 +214,13 @@ Once you have done this, you can run the Unity Editor and test the application.
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Import the `Firebase Auth` plugin.
+  - Import the Firebase Auth plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
-  - Import the `Firebase Functions` plugin.
+  - Import the Firebase Functions plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseFunctions.unitypackage`
@@ -227,7 +228,7 @@ Once you have done this, you can run the Unity Editor and test the application.
       button.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -57,29 +57,17 @@ inside the Unity Editor.
          Click `Confirm` to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
-    - Double click on `MainScene` file to open.
+    - Double click on `MainScene` file to open it.
   - Import the `Firebase Auth` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseAuth.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseAuth.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseAuth.unitypackage` package.
+      downloaded previously, import `FirebaseAuth.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Import the `Firebase Functions` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseFunctions.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseFunctions.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseFunctions.unitypackage` package.
+      downloaded previously, import `FirebaseFunctions.unitypackage`
     - When the **Import Unity Package** window appears, click the **Import**
       button.
 
@@ -87,17 +75,40 @@ Once you have done this, you can run the Unity Editor and test the application.
 
 ## Building the Sample for Devices
 
-### iOS
+### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.functions.testapp` as the
-        bundle identifier when creating the Firebase iOS app in the console.
-        - If you do not use the prescribed package name you will later need to
-          update the bundle identifier in Unity as described in the
+        Apple bundle ID when creating the Unity app in the console.
+        - If you do not use the prescribed Bundle ID, you will later need to
+          update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
+    - Download the `GoogleService-Info.plist` file associated with your
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
+    - For further details please refer to the
+      [general instructions](https://firebase.google.com/docs/ios/setup)
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity)
+    and unzip it somewhere convenient.
+  - Open the sample project in the Unity editor.
+    - Select the `File > Open Project` menu item.
+    - Click `Open`.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Double click on `MainScene` file to open it.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
       window.
@@ -105,6 +116,18 @@ Once you have done this, you can run the Unity Editor and test the application.
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
+  - Import the `Firebase Auth` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseAuth.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
+  - Import the `Firebase Functions` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseFunctions.unitypackage`
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
       as the Apple bundle ID when creating your app in the Firebase
@@ -114,7 +137,7 @@ Once you have done this, you can run the Unity Editor and test the application.
         target.
       - Click `Player Settings`.
       - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        `Bundle Identifier` and update the value to the `Apple bundle ID` you
         provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
@@ -167,6 +190,16 @@ Once you have done this, you can run the Unity Editor and test the application.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
         which describes how to configure a Firebase application for Android.
+  - Open the sample project in the Unity editor.
+    - Select the `File > Open Project` menu item.
+    - Click `Open`.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Double click on `MainScene` file to open it.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
       window.
@@ -174,6 +207,18 @@ Once you have done this, you can run the Unity Editor and test the application.
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
+  - Import the `Firebase Auth` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseAuth.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
+  - Import the `Firebase Functions` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseFunctions.unitypackage`
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Optional: Update the Project Bundle Identifier
     - If you did not use `com.google.firebase.unity.functions.testapp`
       as the `Android package name` when you created your app in the Firebase

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -16,10 +16,12 @@ inside the Unity Editor.
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Deploying functions.
 - Install the [Firebase CLI](https://firebase.google.com/docs/cli/).
@@ -94,20 +96,20 @@ Once you have done this, you can run the Unity Editor and test the application.
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click *Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
@@ -132,20 +134,21 @@ Once you have done this, you can run the Unity Editor and test the application.
     - If you did not use `com.google.firebase.unity.functions.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `Apple bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
+        to **Bundle Identifier** and update the value to the `Apple bundle ID`
+        you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the  **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target
+      platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
 
 ### Android
 
@@ -189,20 +192,21 @@ Once you have done this, you can run the Unity Editor and test the application.
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Functions` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Functions` in the **Project** window.
     - Double click on `MainScene` file to open it.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Functions` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
@@ -219,23 +223,23 @@ Once you have done this, you can run the Unity Editor and test the application.
       downloaded previously, import `FirebaseFunctions.unitypackage`
     - When the **Import Unity Package** window appears, click the **Import**
       button.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the Android package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the Android package name
+        you provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
 
 
 ## Troubleshooting

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -14,6 +14,13 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
+
 ## Deploying functions.
 - Install the [Firebase CLI](https://firebase.google.com/docs/cli/).
 - Deploy the provided functions.
@@ -98,20 +105,21 @@ Once you have done this, you can run the Unity Editor and test the application.
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.functions.testapp`
-      as the iOS bundle ID when creating your app in the Firebase Console then
-      you will need to update the sample's Bundle.
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -261,8 +261,11 @@ Once you have done this, you can run the Unity Editor and test the application.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.`    
 
 
 ## Support

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -153,9 +153,10 @@ Once you have done this, you can run the Unity Editor and test the application.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.functions.testapp` as the
         `Android package name` when you created your app in the Firebase
         Console, you will need to update the sample's Bundle Identifier.
@@ -169,7 +170,8 @@ Once you have done this, you can run the Unity Editor and test the application.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - After setting the keystore and key, you can generate a SHA1 by
@@ -254,7 +256,6 @@ Once you have done this, you can run the Unity Editor and test the application.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/functions/testapp/readme.md
+++ b/functions/testapp/readme.md
@@ -19,9 +19,10 @@ inside the Unity Editor.
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Deploying functions.
 - Install the [Firebase CLI](https://firebase.google.com/docs/cli/).

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -21,7 +21,7 @@ deleting Installations using the Firebase Installations API of the
 
 ## Building the Sample
 
-### iOS
+### iOS or tvOS
 
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
@@ -161,6 +161,9 @@ deleting Installations using the Firebase Installations API of the
 
 
 ## Using the Sample
+
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
+and so will not be responsive on tvOS.
 
 The sample provides a simple interface with several buttons:
 

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -6,21 +6,11 @@ deleting Installations using the Firebase Installations API of the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) 5.3 or higher.
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
 * [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
   (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
-
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
 
 ## Building the Sample
 
@@ -180,6 +170,15 @@ that platform.
     - Click **Build and Run**.
   - See the **Using the Sample** section below.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Using the Sample
 

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -30,7 +30,7 @@ deleting Installations using the Firebase Installations API of the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.installations.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -70,7 +70,7 @@ deleting Installations using the Firebase Installations API of the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.installations.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -87,7 +87,7 @@ deleting Installations using the Firebase Installations API of the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -96,25 +96,38 @@ UI elements on that platform.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.installations.testapp` as the
         package name while you're testing.
         - If you do not use the prescribed package name you will need to update
           the bundle identifier as described in the
           `Optional: Update the Project Bundle Identifier` below.
-
-      - To [generate a SHA1](https://developers.google.com/android/guides/client-auth),
+      - Android apps must be signed by a key, and the key's signature must
+        be registered to your project in the Firebase Console. To
+        [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
-        - Select an existing keystore, or create a new keystore using the toggle.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
+        - Select an existing keystore, or create a new keystore using the
+          toggle.    
         - Select an existing key, or create a new key using "Create a new key".
       - After setting the keystore and key, you can generate a SHA1 by
-        running this command:
-        ```
-        keytool -exportcert -list -v -alias <key_name> -keystore <path_to_keystore>
-        ```
+          running this command:
+          ```
+          keytool -list -v -keystore <path_to_keystore> -alias <key_name>
+          ```
+        - Copy the SHA1 digest string into your clipboard.
+        - Navigate to your Android App in your firebase console.
+        - From the main console view, click on your Android App at the top, then
+          click the gear to open the settings page.
+        - Scroll down to your apps at the bottom of the page and click on
+          `Add Fingerprint`.
+        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          will illuminate if the string is valid. If it's not valid, check
+          that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
         This file identifies your Android app to the Firebase backend, and will

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -7,8 +7,8 @@ deleting Installations using the Firebase Installations API of the
 ## Requirements
 
 * [Unity](http://unity3d.com/) 5.3 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -28,14 +28,14 @@ UI elements on that platform.
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.installations.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -58,7 +58,7 @@ UI elements on that platform.
     - Navigate to `Assets/Firebase/Sample/Installations` in the **Project**
       window.
     - Double click on `MainScene` file to open.
-  - Import the `Firebase Installations` plugin.
+  - Import the Firebase Installations plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseInstallations.unitypackage`.
@@ -73,7 +73,7 @@ UI elements on that platform.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.installations.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
@@ -81,7 +81,7 @@ UI elements on that platform.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
         down to **Bundle Identifier** and update the value to the 
-        `Apple bundle ID` you provided when you registered your app with
+        **Apple bundle ID** you provided when you registered your app with
         Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
@@ -90,7 +90,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -98,13 +98,13 @@ UI elements on that platform.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.installations.testapp` as the
         package name while you're testing.
         - If you do not use the prescribed package name you will need to update
           the bundle identifier as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -113,7 +113,8 @@ UI elements on that platform.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.    
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using 
+          **Create a new key**.
       - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -124,8 +125,8 @@ UI elements on that platform.
         - From the main console view, click on your Android App at the top, then
           click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
           will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
@@ -176,7 +177,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -14,10 +14,12 @@ deleting Installations using the Firebase Installations API of the
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Building the Sample
 
@@ -40,20 +42,21 @@ deleting Installations using the Firebase Installations API of the
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Installations` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Installations` in the **Project**
+      window.
     - Double click on `MainScene` file to open.
   - Import the `Firebase Installations` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -63,7 +66,7 @@ deleting Installations using the Firebase Installations API of the
       button.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Installations` folder in the
-      `Project` window.
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
@@ -72,20 +75,21 @@ deleting Installations using the Firebase Installations API of the
     - If you did not use `com.google.firebase.unity.installations.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
+        down to **Bundle Identifier** and update the value to the 
+        `Apple bundle ID` you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 
@@ -117,17 +121,19 @@ deleting Installations using the Firebase Installations API of the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Installations` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Installations` in the **Project**
+      window.
     - Double click on `MainScene` file to open it.
   - Import the `Firebase Installations` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -135,28 +141,28 @@ deleting Installations using the Firebase Installations API of the
       downloaded previously, import `FirebaseInstallations.unitypackage`.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Installations` folder in the
-      `Project` window.
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.installations.testapp`
       as the project package name you will need to update the sample's Bundle
       Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Player Settings` panel scroll down to `Bundle Identifier`
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Player Settings** panel scroll down to **Bundle Identifier**
         and update the value to the package name you provided when you
         registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -17,9 +17,10 @@ deleting Installations using the Firebase Installations API of the
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Building the Sample
 

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -12,6 +12,12 @@ deleting Installations using the Firebase Installations API of the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
 
 ## Building the Sample
 
@@ -63,20 +69,21 @@ deleting Installations using the Firebase Installations API of the
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.installations.testapp`
-      as the project package name you will need to update the sample's Bundle
-      Identifier.
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Player Settings` panel scroll down to `Bundle Identifier`
-        and update the value to the package name you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
+      - Click `Player Settings`.
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.

--- a/installations/testapp/readme.md
+++ b/installations/testapp/readme.md
@@ -23,22 +23,25 @@ deleting Installations using the Firebase Installations API of the
 
 ### iOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.installations.testapp` as the
-        package name while you're testing.
-        - If you do not use the prescribed package name you will need to update
-          the bundle identifier as described in the
+        Apple bundle ID when creating the Unity app in the console.
+        - If you do not use the prescribed Bundle ID, you will later need to
+          update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
     - Download the `GoogleService-Info.plist` file associated with your
-      Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
-      need to be included in the sample later.
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
@@ -47,19 +50,15 @@ deleting Installations using the Firebase Installations API of the
     - Click `Open`.
     - Navigate to the sample directory `testapp` in the file dialog and click
       `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Installations` in the `Project` window.
     - Double click on `MainScene` file to open.
   - Import the `Firebase Installations` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseInstallations.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseInstallations.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseInstallations.unitypackage` package.
+      downloaded previously, import `FirebaseInstallations.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
@@ -129,17 +128,11 @@ deleting Installations using the Firebase Installations API of the
       `Open`.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Installations` in the `Project` window.
-    - Double click on `MainScene` file to open.
+    - Double click on `MainScene` file to open it.
   - Import the `Firebase Installations` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseInstallations.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseInstallations.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseInstallations.unitypackage` package.
+      downloaded previously, import `FirebaseInstallations.unitypackage`.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Installations` folder in the
       `Project` window.

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -15,16 +15,6 @@ using the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Building the Sample
 
 ### iOS or tvOS
@@ -116,7 +106,7 @@ that platform.
       - Switch **Push Notifications** to **On**.
       - Scroll down to **Background Modes** and switch it to **On**.
       - Tick the **Remote notifications** box under **Background Modes**.
-    - Build the Xcode project by selecting **Project->Run** from the menu.
+    - Build the Xcode project by selecting **Project > Run** from the menu.
   - See the **Using the Sample** section below.
 
 
@@ -215,6 +205,15 @@ that platform.
   ```
   - See the **Using the Sample** section below.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Using the Sample
 

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -122,9 +122,10 @@ UI elements on that platform.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.FirebaseUnityMessagingTestApp.dev` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -134,7 +135,8 @@ UI elements on that platform.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the 
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -290,7 +292,6 @@ curl --header "Authorization: key=<Server Key>" --header "Content-Type: applicat
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -111,8 +111,7 @@ that platform.
       - Scroll down to **Linked Frameworks and Libraries** and click the **+**
         button to add a framework.
         - In the window that appears, scroll to **UserNotifications.framework**
-          and click on that entry, then click on **Add**. This framework will
-          only appear in Xcode version 8 and higher, required by this library.
+          and click on that entry, then click on **Add**.
       - Select the **Capabilities** tab from the **Editor area**.
       - Switch **Push Notifications** to **On**.
       - Scroll down to **Background Modes** and switch it to **On**.
@@ -299,8 +298,11 @@ curl --header "Authorization: key=<Server Key>" --header "Content-Type: applicat
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -113,7 +113,7 @@ using the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -24,16 +24,18 @@ using the
 
 ## Building the Sample
 
-### iOS
+### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityMessagingTestApp.dev` as the
-        iOS bundle ID when creating the Firebase iOS app in the console.
-        - If you do not use the prescribed Bundle ID you will later need to
-          update the bundle identifier in Unity as described in the
+        Apple bundle ID when creating the Unity app in the console.
+        - If you do not use the prescribed Bundle ID, you will later need to
+          update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
     - Associate the project with an
       [APNs certificate](https://firebase.google.com/docs/cloud-messaging/ios/certs)
@@ -46,17 +48,19 @@ using the
         if any. Make sure the bundle ID for this certificate matches the
         bundle ID of your app. Select Save.
     - Download the `GoogleService-Info.plist` file associated with your
-      Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
-      need to be included in the sample later.
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
-  - Download the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
     - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Click `Open`.
     - Navigate to the sample directory `testapp` in the file dialog and click
       `Open`.
       - You might be prompted to upgrade the project to your version of Unity.
@@ -67,13 +71,7 @@ using the
   - Import the `Firebase Cloud Messaging` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseMessaging.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseMessaging.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseMessaging.unitypackage` package.
+      downloaded previously, import `FirebaseMessaging.unitypackage`.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the `Project`
       window.
@@ -174,13 +172,7 @@ using the
   - Import the `Firebase Cloud Messaging` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseMessaging.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseMessaging.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseMessaging.unitypackage` package.
+      downloaded previously, import `FirebaseMessaging.unitypackage`.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the `Project`
       window.

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -20,9 +20,10 @@ using the
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Building the Sample
 

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -17,10 +17,12 @@ using the
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Building the Sample
 
@@ -53,28 +55,28 @@ using the
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - Click `Open`.
+    - Select the **File > Open Project** menu item.
+    - Click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Messaging` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Messaging` in the **Project** window.
     - Double click on `MainScene` file to open it.
   - Import the `Firebase Cloud Messaging` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseMessaging.unitypackage`.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
@@ -83,36 +85,37 @@ using the
     - If you did not use `com.google.FirebaseUnityMessagingTestApp.dev`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
+        down to **Bundle Identifier** and update the value to the
+        `Apple bundle ID` you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and run`, when Xcode opens stop the build.
-      - *NOTE* If you click `Build and run` and let the sample run, it will
+    - Click **Build and run**, when Xcode opens stop the build.
+      - *NOTE* If you click **Build and run** and let the sample run, it will
         not be able to receive messages.
     - Configure the Xcode project for push messaging.
-      - Select the `Unity-iPhone` project from the `Navigator area`.
-      - Select the `Unity-iPhone` target from the `Editor area`.
-      - Select the `General` tab from the `Editor area`.
-      - Scroll down to `Linked Frameworks and Libraries` and click the `+`
+      - Select the **Unity-iPhone** project from the **Navigator area**.
+      - Select the **Unity-iPhone** target from the **Editor area**.
+      - Select the **General** tab from the **Editor area**.
+      - Scroll down to **Linked Frameworks and Libraries** and click the **+**
         button to add a framework.
-        - In the window that appears, scroll to `UserNotifications.framework`
-          and click on that entry, then click on `Add`. This framework will only
-          appear in Xcode version 8 and higher, required by this library.
-      - Select the `Capabilities` tab from the `Editor area`.
-      - Switch `Push Notifications` to `On`.
-      - Scroll down to `Background Modes` and switch it to `On`.
-      - Tick the `Remote notifications` box under `Background Modes`.
-    - Build the Xcode project by selecting `Project->Run` from the menu.
+        - In the window that appears, scroll to **UserNotifications.framework**
+          and click on that entry, then click on **Add**. This framework will
+          only appear in Xcode version 8 and higher, required by this library.
+      - Select the **Capabilities** tab from the **Editor area**.
+      - Switch **Push Notifications** to **On**.
+      - Scroll down to **Background Modes** and switch it to **On**.
+      - Tick the **Remote notifications** box under **Background Modes**.
+    - Build the Xcode project by selecting **Project->Run** from the menu.
   - See the *Using the Sample* section below.
 
 
@@ -155,49 +158,49 @@ using the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
         Click `Confirm` to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Messaging` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Messaging` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Cloud Messaging` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseMessaging.unitypackage`.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Messaging` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityMessagingTestApp.dev`
       as the Android package name when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the package name you
+        provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
-  - See the *Using the Sample* section below.
+    - Click **Build and Run**.
   - Please ensure that you are requesting for `BIND_JOB_SERVICE` permission on messaging services in `AndroidManifest.xml`. Example,
   ```
     <service android:name="com.google.firebase.messaging.MessageForwardingService"
@@ -205,6 +208,7 @@ using the
              android:exported="false" >
     </service>
   ```
+  - See the *Using the Sample* section below.
 
 
 ## Using the Sample
@@ -223,13 +227,13 @@ if you haven't already, then associate it with your sample project in the
     bundle ID of your app. Select Save.
 
 Failure to associate the sample with an APNs certificate will result in the
-iOS application being unable to receive messages.
+iOS or tvOS application being unable to receive messages.
 
   - When you run the app, it will print:
     `Received Registration Token: <registration_token>`
     this token can be used to send a notification to a single device.
-    - When running the app on **iOS**, the token can be accessed via Xcode's
-      console output.
+    - When running the app on **iOS** or **tvOS**, the token can be accessed
+      via Xcode's console output.
     - When running the app on **Android**, the token can be accessed using the
       ADB command line with the `adb logcat` command.
 

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -15,6 +15,12 @@ using the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
 
 ## Building the Sample
 
@@ -77,18 +83,19 @@ using the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityMessagingTestApp.dev`
-      as the iOS bundle ID when creating your app in the Firebase
+      as the Apple bundle ID when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
       - Click `Player Settings`.
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and run`, when Xcode opens stop the build.

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -33,7 +33,7 @@ using the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.FirebaseUnityMessagingTestApp.dev` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -81,7 +81,7 @@ using the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityMessagingTestApp.dev`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -9,9 +9,9 @@ using the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -31,24 +31,25 @@ UI elements on that platform.
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.FirebaseUnityMessagingTestApp.dev` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Associate the project with an
       [APNs certificate](https://firebase.google.com/docs/cloud-messaging/ios/certs)
       - Inside your project in the Firebase console, select the gear icon,
-        select `Project Settings`, and then select the `Cloud Messaging` tab.
-      - Select the `Upload Certificate` button for your development
+        select **Project Settings**, and then select the **Cloud Messaging**
+        tab.
+      - Select the **Upload Certificate** button for your development
         certificate, your production certificate, or both. At least one is
         required.
-      - For each certificate, select the .p12 file, and provide the password,
+      - For each certificate, select the `.p12` file, and provide the password,
         if any. Make sure the bundle ID for this certificate matches the
-        bundle ID of your app. Select Save.
+        bundle ID of your app. Select **Save**.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -70,7 +71,7 @@ UI elements on that platform.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Messaging` in the **Project** window.
     - Double click on `MainScene` file to open it.
-  - Import the `Firebase Cloud Messaging` plugin.
+  - Import the Firebase Cloud Messaging plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseMessaging.unitypackage`.
@@ -83,7 +84,7 @@ UI elements on that platform.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.FirebaseUnityMessagingTestApp.dev`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
@@ -91,7 +92,7 @@ UI elements on that platform.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
         down to **Bundle Identifier** and update the value to the
-        `Apple bundle ID` you provided when you registered your app with
+        **Apple bundle ID** you provided when you registered your app with
         Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
@@ -116,7 +117,7 @@ UI elements on that platform.
       - Scroll down to **Background Modes** and switch it to **On**.
       - Tick the **Remote notifications** box under **Background Modes**.
     - Build the Xcode project by selecting **Project->Run** from the menu.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -124,13 +125,13 @@ UI elements on that platform.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.FirebaseUnityMessagingTestApp.dev` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -139,7 +140,8 @@ UI elements on that platform.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the 
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using 
+          **Create a new key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -150,8 +152,8 @@ UI elements on that platform.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
           will illuminate if the string is valid.  If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
@@ -171,11 +173,11 @@ UI elements on that platform.
     - Navigate to the sample directory `testapp` in the file dialog and click
       **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Messaging` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Cloud Messaging` plugin.
+  - Import the Firebase Cloud Messaging plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseMessaging.unitypackage`.
@@ -203,14 +205,15 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - Please ensure that you are requesting for `BIND_JOB_SERVICE` permission on messaging services in `AndroidManifest.xml`. Example,
+  - Please ensure that you are requesting for `BIND_JOB_SERVICE` permission on
+    messaging services in `AndroidManifest.xml`. Example,
   ```
     <service android:name="com.google.firebase.messaging.MessageForwardingService"
              android:permission="android.permission.BIND_JOB_SERVICE"
              android:exported="false" >
     </service>
   ```
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample
@@ -221,12 +224,12 @@ if you haven't already, then associate it with your sample project in the
 [Firebase console](https://firebase.google.com/console/):
 
   - Inside your project in the Firebase console, select the gear icon,
-    select `Project Settings`, and then select the `Cloud Messaging` tab.
-  - Select the `Upload Certificate` button for your development certificate,
+    select  **Project Settings**, and then select the **Cloud Messaging** tab.
+  - Select the **Upload Certificate** button for your development certificate,
     your production certificate, or both. At least one is required.
-  - For each certificate, select the .p12 file, and provide the password,
+  - For each certificate, select the `.p12` file, and provide the password,
     if any. Make sure the bundle ID for this certificate matches the
-    bundle ID of your app. Select Save.
+    bundle ID of your app. Select **Save**.
 
 Failure to associate the sample with an APNs certificate will result in the
 iOS or tvOS application being unable to receive messages.
@@ -234,31 +237,31 @@ iOS or tvOS application being unable to receive messages.
   - When you run the app, it will print:
     `Received Registration Token: <registration_token>`
     this token can be used to send a notification to a single device.
-    - When running the app on **iOS** or **tvOS**, the token can be accessed
+    - When running the app on iOS or tvOS, the token can be accessed
       via Xcode's console output.
-    - When running the app on **Android**, the token can be accessed using the
+    - When running the app on Android, the token can be accessed using the
       ADB command line with the `adb logcat` command.
 
   - To send messages from your own server or the command line you will need the
      `Server Key`.
     - Open your project in the
       [Firebase Console](https://firebase.google.com/console/)
-    - Click the gear icon then `Project settings` in the menu on the left
-    - Select the `Cloud Messaging` tab.
-    - Copy the `Server Key`
+    - Click the gear icon then **Project settings** in the menu on the left
+    - Select the **Cloud Messaging** tab.
+    - Copy the **Server Key**.
 
   - You can [send a notification to a single device](https://firebase.google.com/docs/cloud-messaging/unity/device-group)
     or group of devices with this token.
     - Using the [Firebase Console](https://firebase.google.com/console/):
       - Open the [Firebase Console](https://firebase.google.com/console/).
-      - Select `Notifications` in the left menu.
-      - Change `Target` to `Single Device` and paste in the
-        `Registration Token` from the device.
-      - Fill out the rest of the field and press `Send Message` to send a
+      - Select **Notifications** in the left menu.
+      - Change **Target** to **Single Device** and paste in the
+        **Registration Token** from the device.
+      - Fill out the rest of the field and press **Send Message** to send a
         notification.
     - Using the command line:
       - Replace `<Server Key>` and `<Registration Token>` in this command and
-        run it from the command line.
+        run it from the command line:
 ```
 curl --header "Authorization: key=<Server Key>" --header "Content-Type: application/json" https://android.googleapis.com/gcm/send -d '{"notification":{"title":"Hi","body":"Hello from the Cloud"},"data":{"score":"lots"},"to":"<Registration Token>"}'
 ```
@@ -267,14 +270,14 @@ curl --header "Authorization: key=<Server Key>" --header "Content-Type: applicat
     (e.g "TestTopic") which notifies all devices subscribed to the topic.
     - Using the [Firebase Console](https://firebase.google.com/console/):
       - Open the [Firebase Console](https://firebase.google.com/console/).
-      - Select `Notifications` in the left menu.
-      - Change `Target` to `Topic` and select the topic (this can take a few
-        hours to appear after devices have subscribed).
-      - Fill out the rest of the field and press `Send Message` to send a
+      - Select **Notifications** in the left menu.
+      - Change **Target** to **Topic** and select the topic (this can take a
+        few hours to appear after devices have subscribed).
+      - Fill out the rest of the field and press **Send Message** to send a
         notification.
     - Using the command line:
       - Replace `<Server Key>` and `<Topic>` in this command and
-        run it from the command line.
+        run it from the command line:
 ```
 curl --header "Authorization: key=<Server Key>" --header "Content-Type: application/json" https://android.googleapis.com/gcm/send -d '{"notification":{"title":"Hi","body":"Hello from the Cloud"},"data":{"score":"lots"},"to":"/topics/<Topic>"}'
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Firebase Unity SDK Samples
 ==========================
 
-iOS and Android samples for the
+iOS, tvOS, and Android samples for the
 [Firebase Unity SDK](https://firebase.google.com/docs/unity/setup).
 
 For more information, see [firebase.google.com](https://firebase.google.com).

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -15,6 +15,12 @@ using the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
 
 ## Building the Sample
 
@@ -68,21 +74,21 @@ using the
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
-      as the iOS bundle ID when creating your app in the Firebase
-      Console then you will need to update the sample's Bundle
-      Identifier.
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
+      - Click `Player Settings`.
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -33,7 +33,7 @@ using the
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.remoteconfig.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -73,7 +73,7 @@ using the
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -99,9 +99,10 @@ UI elements on that platform.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.remoteconfig.testapp` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -111,7 +112,8 @@ UI elements on that platform.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the 
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -229,7 +231,6 @@ Firebase Console and it will be reflected in your app.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -15,16 +15,6 @@ using the
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
-## Notes
-
-### Usage on tvOS
-
-This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS,
-the buttons will be unresponsive as there isn't an easy way to provide
-the app with the click / touch events to orchestrate the UI elements on
-that platform.
-
 ## Building the Sample
 
 ### iOS or tvOS
@@ -187,6 +177,15 @@ that platform.
     - Click **Build and Run**.
   - See the **Using the Sample** section below.
 
+## Notes
+
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Using the Sample
 

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -90,7 +90,7 @@ using the
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -9,9 +9,9 @@ using the
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -33,12 +33,12 @@ UI elements on that platform.
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the `Add app` button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.remoteconfig.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -61,7 +61,7 @@ UI elements on that platform.
     - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the **Project**
       window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Remote Config` plugin.
+  - Import the Firebase Remote Config plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseRemoteConfig.unitypackage`.
@@ -76,15 +76,15 @@ UI elements on that platform.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
         build target.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
-        to **Bundle Identifier** and update the value to the `Apple bundle ID`
-        you provided when you registered your app with Firebase.
+        to **Bundle Identifier** and update the value to the **Apple bundle
+        ID** you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
     - Select either **iOS** or **tvOS** in the **Platform** list.
@@ -93,7 +93,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ### Android
@@ -101,13 +101,13 @@ UI elements on that platform.
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.remoteconfig.testapp` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -116,7 +116,8 @@ UI elements on that platform.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the 
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using
+          **Create a new key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -124,12 +125,12 @@ UI elements on that platform.
           ```
         - Copy the SHA1 digest string into your clipboard.
         - Navigate to your Android App in your firebase console.
-          - From the main console view, click on your Android App at the top and
-            click the gear to open the settings page.
+          - From the main console view, click on your Android App at the top
+            and click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
-          will illuminate if the string is valid.  If it's not valid, check
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
+          will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
@@ -153,7 +154,7 @@ UI elements on that platform.
     - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the **Project**
       window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Remote Config` plugin.
+  - Import the Firebase Remote Config plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseRemoteConfig.unitypackage`.
@@ -168,7 +169,7 @@ UI elements on that platform.
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
-      as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **Android** in the **Platform** list.
@@ -183,7 +184,7 @@ UI elements on that platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 
 ## Using the Sample

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -17,10 +17,12 @@ using the
 
 ## Notes
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+### Usage on tvOS
+
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Building the Sample
 
@@ -43,20 +45,21 @@ using the
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the **Project**
+      window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Remote Config` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -75,20 +78,21 @@ using the
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll down
+        to **Bundle Identifier** and update the value to the `Apple bundle ID`
+        you provided when you registered your app with Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iOS** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target
+      platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 
@@ -131,19 +135,21 @@ using the
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`.  Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/RemoteConfig` in the **Project**
+      window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Remote Config` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -153,28 +159,28 @@ using the
       button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/RemoteConfig` folder in the
-      `Project` window.
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.remoteconfig.testapp`
       as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the package name you provided when you
-        registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to
+        **Bundle Identifier** and update the value to the package name you
+        provided when you registered your app with Firebase.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -236,8 +236,11 @@ Firebase Console and it will be reflected in your app.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - When running the app, if all that you see is a blue horizon, then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 ## Support
 

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -180,6 +180,9 @@ using the
 
 ## Using the Sample
 
+**Note:** the UI elements of the quickstart app respond only to mouse clicks,
+and so will not be responsive on tvOS.
+
 Before running, you should add some data to the Firebase Console for the
 sample to fetch.
 

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -24,24 +24,27 @@ using the
 
 ## Building the Sample
 
-### iOS
+### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.remoteconfig.testapp` as the
-         iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
     - Download the `GoogleService-Info.plist` file associated with your
-      Firebase project from the console.
-      This file identifies your iOS app to the Firebase backend, and will
-      need to be included in the sample later.
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS.
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
@@ -58,13 +61,7 @@ using the
   - Import the `Firebase Remote Config` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseRemoteConfig.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseRemoteConfig.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseRemoteConfig.unitypackage` package.
+      downloaded previously, import `FirebaseRemoteConfig.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
@@ -151,13 +148,7 @@ using the
   - Import the `Firebase Remote Config` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseRemoteConfig.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseRemoteConfig.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseRemoteConfig.unitypackage` package.
+      downloaded previously, import `FirebaseRemoteConfig.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -20,9 +20,10 @@ using the
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Building the Sample
 

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -19,9 +19,10 @@ inside the Unity Editor.
 ### Usage on tvOS
 
 This testapp was designed for use on iOS and Android targets, and when
-running in the Unity editor. While the code will also execute on tvOS, there
-isn't an easy way for users to provide the click events required to use the
-UI elements on that platform.
+running in the Unity editor. While the code will also execute on tvOS,
+the buttons will be unresponsive as there isn't an easy way to provide
+the app with the click / touch events to orchestrate the UI elements on
+that platform.
 
 ## Running the Sample inside the Editor
 

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -62,17 +62,46 @@ download that same text.
 
 ## Building the Sample for Devices
 
-### iOS
+### iOS or tvOS
 
-  - Register your iOS app with Firebase.
+  - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and associate your iOS application.
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
+      - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.storage.testapp` as the
-        iOS bundle ID when creating the Firebase iOS app in the console.
+        Apple bundle ID when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
+    - Download the `GoogleService-Info.plist` file associated with your
+      Firebase project from the console. This file identifies your iOS+
+      app to the Firebase backend, and will need to be included in the sample
+      later.
+    - For further details please refer to the
+      [general instructions](https://firebase.google.com/docs/ios/setup)
+      which describes how to configure a Firebase application for iOS
+      and tvOS.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity)
+    and unzip it somewhere convenient.
+  - Open the sample project in the Unity editor.
+    - Select the `File > Open Project` menu item.
+    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      `Open`.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click `Confirm` to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Storage` in the `Project` window.
+    - Double click on the `MainScene` file to open it.
+  - Import the `Firebase Storage` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseStorage.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `GoogleService-Info.plist` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Storage` folder in the `Project`
       window.

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -14,6 +14,13 @@ inside the Unity Editor.
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
+## Notes
+
+* This testapp was designed for use on iOS and Android targets, and when
+  running in the Unity editor. While the code will also execute on tvOS, there
+  isn't an easy way for users to provide the click events required to use the
+  UI elements on that platform.
+
 ## Running the Sample inside the Editor
 
   - Download the
@@ -73,24 +80,25 @@ download that same text.
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
         `Assets` folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.storage.testapp`
-      as the iOS bundle ID when creating your app in the Firebase
-      Console then you will need to update the sample's Bundle
-      Identifier.
+      as the Apple bundle ID when creating your app in the Firebase
+      Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
-      - Select `iOS` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for iOS` panel scroll down to `Bundle Identifier`
-        and update the value to the `iOS bundle ID` you provided when you
-        registered your app with Firebase.
-  - Build for iOS
+      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
+        target.
+      - Click `Player Settings`.
+      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
+        `Bundle Identifier` and update the value to the `iOS bundle ID` you
+        provided when you registered your app with Firebase.
+  - Build for iOS or tvOS.
     - Select the `File > Build Settings` menu option.
-    - Select `iOS` in the `Platform` list.
-    - Click `Switch Platform` to select `iOS` as the target platform.
+    - Select either `iOS` or `tvOS` in the `Platform` list.
+    - Click `Switch Platform` to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click `Build and Run`.
+  - See the *Using the Sample* section below.
 
 ### Android
 

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -130,9 +130,10 @@ download that same text.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create a project in the
-      [Firebase console](https://firebase.google.com/console/),
-      and attach your Android app to it.
+    - Create an Unity project in the
+      [Firebase console](https://firebase.google.com/console/).
+    - Associate your project to an app by clicking the `Add app` button,
+      and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.storage.testapp` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
@@ -142,7 +143,8 @@ download that same text.
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
         first you will need to set the keystore in the Unity project.
-        - Locate the `Publishing Settings` under `Player Settings`.
+        - Locate the **Publishing Settings** under **Player Settings** in the
+          Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
         - Select an existing key, or create a new key using "Create a new key".
@@ -194,7 +196,7 @@ download that same text.
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
-  - Optional: Update the Project Bundle Identifier
+  - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.storage.testapp`
             as the `Android package name` when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
@@ -224,12 +226,14 @@ download that same text.
     Settings**.  Select your **Custom Keystore** from the dropdown list and
     enter its password.  Then, select your **Project Key** alias and enter
     your key's password.
-    enabled in your project, you'll see compile errors from some types in the
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
     Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
+  - If when running the app all that you see is a blue horizon then please
+    ensure that you followed the steps to **Open the scene `MainScene`**
+    above.
 
 
 ## Support

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -131,7 +131,7 @@ download that same text.
 ### Android
 
   - Register your Android app with Firebase.
-    - Create an Unity project in the
+    - Create a Unity project in the
       [Firebase console](https://firebase.google.com/console/).
     - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -231,9 +231,9 @@ download that same text.
   - Please see the
     [Known Issues](https://firebase.google.com/docs/unity/setup#known-issues)
     section of the
-    Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
+    [Unity Setup Guide](https://firebase.google.com/docs/unity/setup) for other
     troubleshooting topics.
-  - If when running the app all that you see is a blue horizon then please
+  - When running the app, if all that you see is a blue horizon, then please
     ensure that you followed the steps to **Open the scene `MainScene`**
     above.
 

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -16,12 +16,12 @@ inside the Unity Editor.
 
 ## Notes
 
-### tvOS Support
+### Usage on tvOS
 
-* This testapp was designed for use on iOS and Android targets, and when
-  running in the Unity editor. While the code will also execute on tvOS, there
-  isn't an easy way for users to provide the click events required to use the
-  UI elements on that platform.
+This testapp was designed for use on iOS and Android targets, and when
+running in the Unity editor. While the code will also execute on tvOS, there
+isn't an easy way for users to provide the click events required to use the
+UI elements on that platform.
 
 ## Running the Sample inside the Editor
 
@@ -29,34 +29,29 @@ inside the Unity Editor.
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Storage` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Storage` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Storage` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
-      downloaded previously, import `FirebaseStorage.unitypackage` from the
-      directory that matches the version of Unity you use:
-       - Unity 5.x and earlier use the .NET 3.x framework, so you need to
-         import the `dotnet3/FirebaseStorage.unitypackage` package .
-       - Unity 2017.x and newer allow the use of the .NET 4.x framework.  If
-         your project is configured to use .NET 4.x, import the
-         `dotnet4/FirebaseStorage.unitypackage` package.
+      downloaded previously, import `FirebaseStorage.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Turn off secure access using [Public Rules](https://firebase.google.com/docs/storage/security/start)
     - Navigate to the Storage tab in the firebase console.
     - In the Rules section, replace the line
-    `allow read, write: if request.auth != null;` with `allow read, write;`
-  - Change the line `private const string MyStorageBucket = "gs://YOUR-FIREBASE-BUCKET/";`
-    to replace YOUR-FIREBASE-BUCKET with the bucket found in the
-    firebase console under the Storage tab.
+      `allow read, write: if request.auth != null;` with `allow read, write;`
+  - Change the line
+    `private const string MyStorageBucket = "gs://YOUR-FIREBASE-BUCKET/";` to
+    replace `YOUR-FIREBASE-BUCKET` with the bucket found in the Firebase
+    console under the Storage tab.
 
 Once you have done this, you can run the Unity Editor and test the application.
 You will be able to enter text to upload to Cloud Storage and afterwards
@@ -83,20 +78,20 @@ download that same text.
       later.
     - For further details please refer to the
       [general instructions](https://firebase.google.com/docs/ios/setup)
-      which describes how to configure a Firebase application for iOS
+      page which describes how to configure a Firebase application for iOS
       and tvOS.
   - Download the
     [Firebase Unity SDK](https://firebase.google.com/download/unity)
     and unzip it somewhere convenient.
   - Open the sample project in the Unity editor.
-    - Select the `File > Open Project` menu item.
-    - If Unity Hub appears, click `Add`. Otherwise click `Open`.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**. Otherwise click **Open**.
     - Navigate to the sample directory `testapp` in the file dialog and click
-      `Open`.
+      **Open**.
       - You might be prompted to upgrade the project to your version of Unity.
-        Click `Confirm` to upgrade the project and continue.
+        Click **Confirm** to upgrade the project and continue.
   - Open the scene `MainScene`.
-    - Navigate to `Assets/Firebase/Sample/Storage` in the `Project` window.
+    - Navigate to `Assets/Firebase/Sample/Storage` in the **Project** window.
     - Double click on the `MainScene` file to open it.
   - Import the `Firebase Storage` plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
@@ -105,8 +100,8 @@ download that same text.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `GoogleService-Info.plist` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Storage` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Storage` folder in the
+      **Project** window.
     - Drag the `GoogleService-Info.plist` downloaded from the Firebase console
       into the folder.
       - NOTE: `GoogleService-Info.plist` can be placed anywhere under the
@@ -115,20 +110,21 @@ download that same text.
     - If you did not use `com.google.firebase.unity.storage.testapp`
       as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `iOS` or `tvOS` in the `Platform` list, depending on your build
-        target.
-      - Click `Player Settings`.
-      - In the `Settings for iOS` or `Settings for tvOS` panel, scroll down to
-        `Bundle Identifier` and update the value to the `iOS bundle ID` you
-        provided when you registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **iOS** or **tvOS** in the **Platform** list, depending on your
+        build target.
+      - Click **Player Settings**.
+      - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
+        down to **Bundle Identifier** and update the value to the
+        `Apple bundle ID` you provided when you registered your app with
+        Firebase.
   - Build for iOS or tvOS.
-    - Select the `File > Build Settings` menu option.
-    - Select either `iOS` or `tvOS` in the `Platform` list.
-    - Click `Switch Platform` to enable your selection as the target platform.
+    - Select the **File > Build Settings** menu option.
+    - Select either **iO** or **tvOS** in the **Platform** list.
+    - Click **Switch Platform** to enable your selection as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
+    - Click **Build and Run**.
   - See the *Using the Sample* section below.
 
 ### Android
@@ -156,7 +152,7 @@ download that same text.
           keytool -list -v -keystore <path_to_keystore> -alias <key_name>
           ```
         - Copy the SHA1 digest string into your clipboard.
-        - Navigate to your Android App in your firebase console.
+        - Navigate to your Android App in your Firebase console.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
@@ -170,7 +166,27 @@ download that same text.
         need to be included in the sample later.
       - For further details please refer to the
         [general instructions](https://firebase.google.com/docs/android/setup)
-        which describes how to configure a Firebase application for Android.
+        page which describes how to configure a Firebase application for
+        Android.
+  - Download the
+    [Firebase Unity SDK](https://firebase.google.com/download/unity) and unzip
+    it somewhere convenient.
+  - Open the sample project in the Unity editor.
+    - Select the **File > Open Project** menu item.
+    - If Unity Hub appears, click **Add**.  Otherwise click **Open**.
+    - Navigate to the sample directory `testapp` in the file dialog and click
+      **Open**.
+      - You might be prompted to upgrade the project to your version of Unity.
+        Click **Confirm** to upgrade the project and continue.
+  - Open the scene `MainScene`.
+    - Navigate to `Assets/Firebase/Sample/Storage` in the **Project** window.
+    - Double click on the `MainScene` file to open it.
+  - Import the `Firebase Storage` plugin.
+    - Select the **Assets > Import Package > Custom Package** menu item.
+    - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
+      downloaded previously, import `FirebaseStorage.unitypackage`.
+    - When the **Import Unity Package** window appears, click the **Import**
+      button.
   - Add the `google-services.json` file to the project.
     - Navigate to the `Assets/Firebase/Sample/Storage` folder in the `Project`
       window.
@@ -188,14 +204,13 @@ download that same text.
       - In the `Settings for Android` panel scroll down to `Bundle Identifier`
         and update the value to the package name you provided when you
         registered your app with Firebase.
-  - Build for Android
-    - Select the `File > Build Settings` menu option.
-    - Select `Android` in the `Platform` list.
-    - Click `Switch Platform` to select `Android` as the target platform.
+  - Build for Android.
+    - Select the **File > Build Settings** menu option.
+    - Select **Android** in the **Platform** list.
+    - Click **Switch Platform** to select **Android** as the target platform.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
-    - Click `Build and Run`.
-
+    - Click **Build and Run**.
 
 ## Troubleshooting
 

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -73,7 +73,7 @@ download that same text.
       and selecting the **Unity** icon.
       - Check the box labeled `Register as Apple app`.
       - You should use `com.google.firebase.unity.storage.testapp` as the
-        Apple bundle ID when creating the Unity app in the console.
+        `Apple bundle ID` when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
           `Optional: Update the Project Bundle Identifier` below.
@@ -113,7 +113,7 @@ download that same text.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.storage.testapp`
-      as the Apple bundle ID when creating your app in the Firebase
+      as the `Apple bundle ID` when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the `File > Build Settings` menu option.
       - Select `iOS` or `tvOS` in the `Platform` list, depending on your build

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -8,9 +8,9 @@ inside the Unity Editor.
 
 ## Requirements
 
-* [Unity](http://unity3d.com/) The quickstart project requires 2017.4 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 10.3 or higher
-  (when developing for iOS).
+* [Unity](http://unity3d.com/) The quickstart project requires 2019 or higher.
+* [Xcode](https://developer.apple.com/xcode/) 13.3.1 or higher
+  (when developing for iOS or tvOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).
 
@@ -64,14 +64,14 @@ download that same text.
   - Register your iOS+ (iOS or tvOS) app with Firebase.
     - Create a project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
-      - Check the box labeled `Register as Apple app`.
+      - Check the box labeled **Register as Apple app**.
       - You should use `com.google.firebase.unity.storage.testapp` as the
-        `Apple bundle ID` when creating the Unity app in the console.
+        **Apple bundle ID** when creating the Unity app in the console.
         - If you do not use the prescribed Bundle ID, you will later need to
           update the bundle identifier in Unity as described in
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
     - Download the `GoogleService-Info.plist` file associated with your
       Firebase project from the console. This file identifies your iOS+
       app to the Firebase backend, and will need to be included in the sample
@@ -93,7 +93,7 @@ download that same text.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Storage` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Storage` plugin.
+  - Import the Firebase Storage plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseStorage.unitypackage`.
@@ -108,7 +108,7 @@ download that same text.
         `Assets` folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.storage.testapp`
-      as the `Apple bundle ID` when creating your app in the Firebase
+      as the **Apple bundle ID** when creating your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
       - Select the **File > Build Settings** menu option.
       - Select **iOS** or **tvOS** in the **Platform** list, depending on your
@@ -116,7 +116,7 @@ download that same text.
       - Click **Player Settings**.
       - In the **Settings for iOS** or **Settings for tvOS** panel, scroll
         down to **Bundle Identifier** and update the value to the
-        `Apple bundle ID` you provided when you registered your app with
+        **Apple bundle ID** you provided when you registered your app with
         Firebase.
   - Build for iOS or tvOS.
     - Select the **File > Build Settings** menu option.
@@ -125,20 +125,20 @@ download that same text.
     - Wait for the spinner (compiling) icon to stop in the bottom right corner
       of the Unity status bar.
     - Click **Build and Run**.
-  - See the *Using the Sample* section below.
+  - See the **Using the Sample** section below.
 
 ### Android
 
   - Register your Android app with Firebase.
     - Create an Unity project in the
       [Firebase console](https://firebase.google.com/console/).
-    - Associate your project to an app by clicking the `Add app` button,
+    - Associate your project to an app by clicking the **Add app** button,
       and selecting the **Unity** icon.
       - You should use `com.google.firebase.unity.storage.testapp` as the
         Android package name while you're testing.
         - If you do not use the prescribed package name, you will need to update
           the bundle identifier as described in the
-          `Optional: Update the Project Bundle Identifier` below.
+          **Optional: Update the Project Bundle Identifier** below.
       - Android apps must be signed by a key, and the key's signature must
         be registered to your project in the Firebase Console. To
         [generate a SHA1](https://developers.google.com/android/guides/client-auth),
@@ -147,7 +147,8 @@ download that same text.
           Unity editor.
         - Select an existing keystore, or create a new keystore using the
           toggle.
-        - Select an existing key, or create a new key using "Create a new key".
+        - Select an existing key, or create a new key using **Create a new
+          key**.
         - After setting the keystore and key, you can generate a SHA1 by
           running this command:
           ```
@@ -158,9 +159,9 @@ download that same text.
           - From the main console view, click on your Android App at the top and
             click the gear to open the settings page.
         - Scroll down to your apps at the bottom of the page and click on
-          `Add Fingerprint`.
-        - Paste the SHA1 digest of your key into the form.  The SHA1 box
-          will illuminate if the string is valid.  If it's not valid, check
+          **Add Fingerprint**.
+        - Paste the SHA1 digest of your key into the form. The SHA1 box
+          will illuminate if the string is valid. If it's not valid, check
           that you have copied the entire SHA1 digest string.
     - Download the `google-services.json` file associated with your
         Firebase project from the console.
@@ -183,29 +184,29 @@ download that same text.
   - Open the scene `MainScene`.
     - Navigate to `Assets/Firebase/Sample/Storage` in the **Project** window.
     - Double click on the `MainScene` file to open it.
-  - Import the `Firebase Storage` plugin.
+  - Import the **Firebase Storage plugin.
     - Select the **Assets > Import Package > Custom Package** menu item.
     - From the [Firebase Unity SDK](https://firebase.google.com/download/unity)
       downloaded previously, import `FirebaseStorage.unitypackage`.
     - When the **Import Unity Package** window appears, click the **Import**
       button.
   - Add the `google-services.json` file to the project.
-    - Navigate to the `Assets/Firebase/Sample/Storage` folder in the `Project`
-      window.
+    - Navigate to the `Assets/Firebase/Sample/Storage` folder in the
+      **Project** window.
     - Drag the `google-services.json` downloaded from the Firebase console
       into the folder.
       - NOTE: `google-services.json` can be placed anywhere under the `Assets`
         folder.
   - Optional: Update the Project Bundle Identifier.
     - If you did not use `com.google.firebase.unity.storage.testapp`
-            as the `Android package name` when you created your app in the Firebase
+      as the **Android package name** when you created your app in the Firebase
       Console, you will need to update the sample's Bundle Identifier.
-      - Select the `File > Build Settings` menu option.
-      - Select `Android` in the `Platform` list.
-      - Click `Player Settings`
-      - In the `Settings for Android` panel scroll down to `Bundle Identifier`
-        and update the value to the package name you provided when you
-        registered your app with Firebase.
+      - Select the **File > Build Settings** menu option.
+      - Select **Android** in the **Platform** list.
+      - Click **Player Settings**.
+      - In the **Settings for Android** panel scroll down to **Bundle
+        Identifier** and update the value to the package name you provided when
+        you registered your app with Firebase.
   - Build for Android.
     - Select the **File > Build Settings** menu option.
     - Select **Android** in the **Platform** list.

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -16,6 +16,8 @@ inside the Unity Editor.
 
 ## Notes
 
+### tvOS Support
+
 * This testapp was designed for use on iOS and Android targets, and when
   running in the Unity editor. While the code will also execute on tvOS, there
   isn't an easy way for users to provide the click events required to use the


### PR DESCRIPTION
A revision of the Quickstart App instructions for tvOS and general clarity.

Changes were made to:

- Normalize use of text formatting:
  - UI elements are now always represented as **bold text**.
  - File names and strings are now in `code blocks`.
  - Previously the documentation switched back and forth between different conventions.
- Normalize instructions on how to open the testapp and the Main Scene. Some quickstarts had varying text here, some lacked any sort of documentation on the subject.
- Ensure each platform has explicit setup steps for both iOS and Android.
  - Some testapps assumed that the user had completed steps in the desktop setup.
- Update docs on Unity Editor and Xcode minimum versions.
- Update iOS section to be applicable to tvOS, too.
- Add a comment that the testapp's UI elements don't respond to clicks on tvOS.
- Update instructions for the  Project <-> App association flow in the Firebase console.
  - click the Unity icon instead of assuming the user clicks the Android / iOS icon.
  - Update "**iOS Bundle Id**" to "**Apple Bundle Id**", which is how it is now presented in the Firebase console.
- Remove the .net v3.5 `.unitypackage` instructions.
- Fix punctuation.
