### PR TITLE
Chore: FirebaseAI update model to work past march

### DIFF
--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandler.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandler.cs
@@ -56,7 +56,7 @@ namespace Firebase.Sample.FirebaseAI {
       });
     }
 
-    public string ModelName = "gemini-2.0-flash";
+    public string ModelName = "gemini-2.5-flash-lite";
 
     private int backendSelection = 0;
     private string[] backendChoices = new string[] { "Google AI Backend", "Vertex AI Backend" };


### PR DESCRIPTION
Gemini 2.0 is to be deprecated in march so update this sample to gemini 2.5