### PR TITLE
Add Sign in with Apple to Auth sample

### DIFF
--- a/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
+++ b/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
@@ -898,6 +898,19 @@ namespace Firebase.Sample.Auth {
           UnlinkUser(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
         }
 
+        if (GUILayout.Button("SignInWith | Apple")) {
+          SignInWithProvider(Firebase.Auth.AppleAuthProvider.ProviderId);
+        }
+        if (GUILayout.Button("ReauthWith | Apple")) {
+          ReauthenticateWithProvider(Firebase.Auth.AppleAuthProvider.ProviderId);
+        }
+        if (GUILayout.Button("LinkWith | Apple")) {
+          LinkWithProvider(Firebase.Auth.AppleAuthProvider.ProviderId);
+        }
+        if (GUILayout.Button("Unlink User | Apple")) {
+          UnlinkUser(Firebase.Auth.AppleAuthProvider.ProviderId);
+        }
+
         GUIDisplayCustomControls();
         GUILayout.EndVertical();
         GUILayout.EndScrollView();


### PR DESCRIPTION
This PR updates the Auth sample application to include support for Sign in with Apple.
It adds four new buttons to the UI:
- Sign In with Apple
- Re-authenticate with Apple
- Link with Apple
- Unlink User | Apple

These buttons use the existing helper methods `SignInWithProvider`, `ReauthenticateWithProvider`, `LinkWithProvider`, and `UnlinkUser` passing the `Firebase.Auth.AppleAuthProvider.ProviderId`.
This aligns the sample with the capabilities of the Firebase Unity SDK which supports Sign in with Apple.

---
*PR created automatically by Jules for task [16758141306176492596](https://jules.google.com/task/16758141306176492596) started by @AustinBenoit*