### PR TITLE
removed deprecated ParameterGroupID

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
@@ -96,13 +96,6 @@ namespace Firebase.Sample.Analytics {
         42);
     }
 
-    public void AnalyticsGroupJoin() {
-      // Log an event with a string parameter.
-      DebugLog("Logging a group join event.");
-      FirebaseAnalytics.LogEvent(FirebaseAnalytics.EventJoinGroup, FirebaseAnalytics.ParameterGroupId,
-        "spoon_welders");
-    }
-
     public void AnalyticsLevelUp() {
       // Log an event with multiple parameters.
       DebugLog("Logging a level up event.");
@@ -177,9 +170,6 @@ namespace Firebase.Sample.Analytics {
         }
         if (GUILayout.Button("Log Score")) {
           AnalyticsScore();
-        }
-        if (GUILayout.Button("Log Group Join")) {
-          AnalyticsGroupJoin();
         }
         if (GUILayout.Button("Log Level Up")) {
           AnalyticsLevelUp();


### PR DESCRIPTION
I removed all ParameterGroupID references within the Quickstart project for Analytics as it's already deprecated (see [here](https://github.com/firebase/firebase-unity-sdk/pull/1280)) and was causing errors :  
<img width="1850" height="200" alt="image" src="https://github.com/user-attachments/assets/29a0c24b-55c3-4a59-bb99-8776c9682935" />
